### PR TITLE
fix: skip auth gate when auth is disabled

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -55,8 +55,7 @@ export function App() {
   }, [csrfToken]);
 
   React.useEffect(() => {
-    const shouldBlockForAuth =
-      authFailed || (authLoaded && !authenticated && (authEnabled || csrfToken === ''));
+    const shouldBlockForAuth = authFailed || (authLoaded && authEnabled && !authenticated);
 
     if (!authLoaded) {
       return;
@@ -71,6 +70,7 @@ export function App() {
     getConfig();
     getUnraid();
   }, [
+    authFailed,
     authLoaded,
     authEnabled,
     authenticated,
@@ -85,7 +85,7 @@ export function App() {
   }
 
   const shouldShowAuthGate =
-    authFailed || (authLoaded && !authenticated && (authEnabled || csrfToken === ''));
+    authFailed || (authLoaded && authEnabled && !authenticated);
 
   if (shouldShowAuthGate) {
     return (


### PR DESCRIPTION
## Summary
- fix the auth gate condition when authentication is disabled
- stop blocking app boot on an empty CSRF token when auth is off
- keep the login gate only for real auth-enabled unauthenticated states

## Validation
- reviewed the UI diff locally
- attempted `npm run build` in `ui/`, but local dependencies are not installed in this environment (`tsc: command not found`)

## Context
This fixes the case where the app still shows the sign-in screen even when Authentication is disabled in settings.