### PR TITLE
feat: migrate auth hashes to argon2id

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,19 @@ After installing the plugin, you can access the web UI, via the following method
 - Method 3<br/> Navigate with your browser to http(s)://Tower:7090/ (replace Tower with the address/name of your Unraid
   server)<br/>
 
+## Authentication
+
+When authentication is enabled, the first administrator to open the web UI completes a one-time password setup.
+
+Password requirements:
+
+- Minimum length: 8 characters
+- Maximum length: 256 characters
+- Special characters: allowed
+- Complexity rules: none (no uppercase, number, or symbol requirement)
+
+New passwords are stored with Argon2id. Existing bcrypt hashes remain supported and are automatically upgraded to Argon2id after the next successful login.
+
 ## Other Features
 
 ### Transfer

--- a/daemon/lib/utils.go
+++ b/daemon/lib/utils.go
@@ -155,9 +155,10 @@ func Bind(content any, data any) error {
 }
 
 // LoadAuthHash reads AUTH_PASSWORD_HASH directly from the env file via the ini
-// library. We bypass the start script's bash sourcing because bcrypt hashes
-// contain $-prefixed segments (e.g. $2a$10$...) that bash treats as parameter
-// expansion, mangling the value before the daemon ever sees it.
+// library. We bypass the start script's bash sourcing because password hashes
+// contain $-prefixed segments (for example bcrypt and Argon2id PHC strings)
+// that bash treats as parameter expansion, mangling the value before the daemon
+// ever sees it.
 func LoadAuthHash(location string) (string, error) {
 	file, err := ini.Load(location)
 	if err != nil {

--- a/daemon/services/server/auth.go
+++ b/daemon/services/server/auth.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"golang.org/x/crypto/bcrypt"
 
 	"unbalance/daemon/common"
 	"unbalance/daemon/logger"
@@ -111,9 +110,28 @@ func (s *Server) login(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
 	}
 
-	if err := bcrypt.CompareHashAndPassword([]byte(s.ctx.AuthPassword), []byte(payload.Password)); err != nil {
+	ok, needsRehash, err := verifyPassword(s.ctx.AuthPassword, payload.Password)
+	if err != nil {
+		logger.Red("unable to verify auth password: %s", err)
 		s.recordLoginFailure(clientKey)
 		return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
+	}
+	if !ok {
+		s.recordLoginFailure(clientKey)
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid credentials")
+	}
+
+	if needsRehash {
+		upgradedHash, err := hashPassword(payload.Password)
+		if err != nil {
+			logger.Red("unable to re-hash auth password: %s", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "unable to upgrade password")
+		}
+		if err := s.core.SetAuth(upgradedHash); err != nil {
+			logger.Red("unable to persist upgraded auth password: %s", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "unable to upgrade password")
+		}
+		s.ctx.AuthPassword = upgradedHash
 	}
 
 	s.clearLoginFailures(clientKey)
@@ -161,21 +179,22 @@ func (s *Server) setup(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusConflict, "authentication is already configured")
 	}
 
-	if len(payload.Password) < 8 {
-		return echo.NewHTTPError(http.StatusBadRequest, "password must be at least 8 characters")
+	if err := validatePassword(payload.Password); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(payload.Password), bcrypt.DefaultCost)
+	hash, err := hashPassword(payload.Password)
 	if err != nil {
 		logger.Red("unable to hash auth password: %s", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "unable to save password")
 	}
 
-	if err := s.core.SetAuth(string(hash)); err != nil {
+	if err := s.core.SetAuth(hash); err != nil {
 		logger.Red("unable to persist auth credentials: %s", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "unable to persist password")
 	}
 
+	s.ctx.AuthPassword = hash
 	s.clearAllSessions()
 
 	sess, err := s.createSession(c, s.ctx.AuthUsername)

--- a/daemon/services/server/password.go
+++ b/daemon/services/server/password.go
@@ -1,0 +1,162 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/crypto/argon2"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	passwordMinChars    = 8
+	passwordMaxChars    = 256
+	argon2Time          = 1
+	argon2Memory        = 64 * 1024
+	argon2Parallelism   = 4
+	argon2SaltLength    = 16
+	argon2KeyLength     = 32
+	argon2VariantPrefix = "$argon2id$"
+)
+
+func validatePassword(password string) error {
+	length := utf8.RuneCountInString(password)
+	if length < passwordMinChars {
+		return fmt.Errorf("password must be at least %d characters", passwordMinChars)
+	}
+
+	if length > passwordMaxChars {
+		return fmt.Errorf("password must be %d characters or fewer", passwordMaxChars)
+	}
+
+	return nil
+}
+
+func hashPassword(password string) (string, error) {
+	if err := validatePassword(password); err != nil {
+		return "", err
+	}
+
+	salt := make([]byte, argon2SaltLength)
+	if _, err := rand.Read(salt); err != nil {
+		return "", err
+	}
+
+	hash := argon2.IDKey([]byte(password), salt, argon2Time, argon2Memory, argon2Parallelism, argon2KeyLength)
+
+	encodedSalt := base64.RawStdEncoding.EncodeToString(salt)
+	encodedHash := base64.RawStdEncoding.EncodeToString(hash)
+
+	return fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s", argon2.Version, argon2Memory, argon2Time, argon2Parallelism, encodedSalt, encodedHash), nil
+}
+
+func verifyPassword(storedHash, password string) (bool, bool, error) {
+	switch {
+	case isBcryptHash(storedHash):
+		if err := bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(password)); err != nil {
+			if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+				return false, false, nil
+			}
+			return false, false, err
+		}
+		return true, true, nil
+	case strings.HasPrefix(storedHash, argon2VariantPrefix):
+		ok, err := verifyArgon2idPassword(storedHash, password)
+		return ok, false, err
+	case storedHash == "":
+		return false, false, nil
+	default:
+		return false, false, fmt.Errorf("unsupported password hash format")
+	}
+}
+
+func isBcryptHash(hash string) bool {
+	return strings.HasPrefix(hash, "$2a$") || strings.HasPrefix(hash, "$2b$") || strings.HasPrefix(hash, "$2y$")
+}
+
+type argon2Params struct {
+	memory      uint32
+	time        uint32
+	parallelism uint8
+	salt        []byte
+	hash        []byte
+}
+
+func verifyArgon2idPassword(encodedHash, password string) (bool, error) {
+	params, err := parseArgon2idHash(encodedHash)
+	if err != nil {
+		return false, err
+	}
+
+	computedHash := argon2.IDKey([]byte(password), params.salt, params.time, params.memory, params.parallelism, uint32(len(params.hash)))
+	return subtle.ConstantTimeCompare(computedHash, params.hash) == 1, nil
+}
+
+func parseArgon2idHash(encodedHash string) (*argon2Params, error) {
+	parts := strings.Split(encodedHash, "$")
+	if len(parts) != 6 || parts[1] != "argon2id" {
+		return nil, fmt.Errorf("invalid argon2id hash format")
+	}
+
+	versionParts := strings.SplitN(parts[2], "=", 2)
+	if len(versionParts) != 2 || versionParts[0] != "v" {
+		return nil, fmt.Errorf("invalid argon2id version")
+	}
+	version, err := strconv.Atoi(versionParts[1])
+	if err != nil {
+		return nil, err
+	}
+	if version != argon2.Version {
+		return nil, fmt.Errorf("unsupported argon2 version %d", version)
+	}
+
+	params := &argon2Params{}
+	for _, item := range strings.Split(parts[3], ",") {
+		kv := strings.SplitN(item, "=", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid argon2 parameter")
+		}
+
+		switch kv[0] {
+		case "m":
+			value, err := strconv.ParseUint(kv[1], 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			params.memory = uint32(value)
+		case "t":
+			value, err := strconv.ParseUint(kv[1], 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			params.time = uint32(value)
+		case "p":
+			value, err := strconv.ParseUint(kv[1], 10, 8)
+			if err != nil {
+				return nil, err
+			}
+			params.parallelism = uint8(value)
+		default:
+			return nil, fmt.Errorf("unsupported argon2 parameter %q", kv[0])
+		}
+	}
+
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return nil, err
+	}
+	hash, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return nil, err
+	}
+
+	params.salt = salt
+	params.hash = hash
+	return params, nil
+}

--- a/meta/plugin/unbalanced.page
+++ b/meta/plugin/unbalanced.page
@@ -109,6 +109,7 @@ $unbalanced_version = shell_exec("cat /usr/local/emhttp/plugins/unbalanced/VERSI
 	<div class="info-block">
 		<div class="info-title">Password Setup</div>
 		<div class="info-content">When authentication is enabled, open unbalanced and complete the one-time password setup screen.</div>
+		<div class="info-content" style="margin-top:6px;">Passwords must be 8-256 characters. Special characters are allowed, and there are no uppercase, number, or symbol requirements.</div>
 	</div>
 
 	<div class="info-block">

--- a/ui/src/components/auth-gate.tsx
+++ b/ui/src/components/auth-gate.tsx
@@ -75,6 +75,8 @@ export function AuthGate() {
           <p className="text-sm leading-6 text-slate-300">
             Authentication is enabled, but no admin password has been created
             yet. The first administrator to open the app must complete setup.
+            Passwords must be 8-256 characters. Special characters are allowed,
+            and there are no uppercase, number, or symbol requirements.
           </p>
         )}
 

--- a/unbalance.go
+++ b/unbalance.go
@@ -33,7 +33,7 @@ var cli struct {
 	RefreshRate    int      `env:"REFRESH_RATE" default:"1000" help:"how often to refresh the ui while running a command (in milliseconds)"`
 	AuthEnabled    bool     `env:"AUTH_ENABLED" default:"false" help:"require login before using the web ui"`
 	AuthUsername   string   `env:"AUTH_USERNAME" default:"admin" help:"admin username used to log into the web ui"`
-	AuthPassword   string   `env:"AUTH_PASSWORD_HASH" default:"" help:"bcrypt hash for the admin password"`
+	AuthPassword   string   `env:"AUTH_PASSWORD_HASH" default:"" help:"stored admin password hash (Argon2id for new passwords; bcrypt remains supported for migration)"`
 
 	Boot cmd.Boot `cmd:"" default:"1" help:"start processing"`
 }
@@ -56,7 +56,7 @@ func main() {
 	})
 
 	// Read AUTH_PASSWORD_HASH directly from disk to sidestep bash's mangling
-	// of $-characters in the bcrypt hash when the start script sources the
+	// of $-characters in password hashes when the start script sources the
 	// env file. Kong's env-driven value is intentionally overridden.
 	envPath := filepath.Join(common.PluginLocation, "unbalanced.env")
 	if hash, err := lib.LoadAuthHash(envPath); err != nil {


### PR DESCRIPTION
## Summary
- add Argon2id as the default password hashing scheme for new password setup
- keep existing bcrypt hashes working and auto-upgrade them to Argon2id after the next successful login
- document the updated password rules and migration behavior in the UI and plugin docs

## Changes
- add a focused password helper for validation, Argon2id hashing, Argon2id PHC parsing, and bcrypt/Argon2id verification
- update login to detect the stored hash format and persist an Argon2id hash after successful bcrypt authentication
- update setup to store Argon2id hashes and enforce an app-level password length range of 8-256 characters
- refresh README, auth setup copy, plugin settings copy, and auth hash comments/help text

## Validation
- `cd ui && npm run build` ✅
- `GOOS=linux GOARCH=amd64 go test ./...` ⚠️ fails in `daemon/services/core/operation.go` due to existing logger format-string issues unrelated to this auth change
