### PR TITLE
harden move source deletion paths

### DIFF
--- a/daemon/services/core/helper.go
+++ b/daemon/services/core/helper.go
@@ -478,9 +478,9 @@ func showPotentiallyPrunedItems(operation *domain.Operation, command *domain.Com
 	if operation.DryRun && operation.OpKind == common.OpGatherMove {
 		parent := filepath.Dir(command.Entry)
 		if parent != "." {
-			logger.Blue(`Would delete empty folders starting from (%s) - (find "%s" -type d -empty -prune -exec rm -rf {} \;) `, filepath.Join(command.Src, parent), filepath.Join(command.Src, parent))
+			logger.Blue("Would prune empty parent folders starting from (%s)", filepath.Join(command.Src, parent))
 		} else {
-			logger.Blue(`WONT DELETE: find "%s" -type d -empty -prune -exec rm -rf {} \;`, filepath.Join(command.Src, parent))
+			logger.Blue("WONT PRUNE: (%s)", filepath.Join(command.Src, parent))
 		}
 	}
 }

--- a/daemon/services/core/operation.go
+++ b/daemon/services/core/operation.go
@@ -196,7 +196,7 @@ func (c *Core) commandInterrupted(opName string, operation *domain.Operation, co
 	subject := fmt.Sprintf("unbalanced - %s operation INTERRUPTED", strings.ToUpper(opName))
 	headline := fmt.Sprintf("Command Interrupted: %s (%s)", cmd, err.Error()+" : "+getError(err.Error(), reRsync, rsyncErrors))
 
-	logger.Yellow(headline)
+	logger.Yellow("%s", headline)
 	packet := &domain.Packet{Topic: common.EventOperationError, Payload: fmt.Sprintf("%s operation was interrupted. Check log (/var/log/unbalanced.log) for additional details.", opName)}
 	c.ctx.Hub.Pub(packet, "socket:broadcast")
 
@@ -216,7 +216,7 @@ func (c *Core) commandInterrupted(opName string, operation *domain.Operation, co
 
 func (c *Core) commandCompleted(operation *domain.Operation, command *domain.Command) {
 	text := "Command Finished"
-	logger.Blue(text)
+	logger.Blue("%s", text)
 
 	operation.BytesTransferred += command.Size
 	percent, left, _ := progress(operation.BytesToTransfer, operation.BytesTransferred, time.Since(operation.Started))
@@ -252,68 +252,31 @@ func (c *Core) handleItemDeletion(operation *domain.Operation, command *domain.C
 
 			packet := &domain.Packet{Topic: common.EventTransferProgress, Payload: operation}
 			c.ctx.Hub.Pub(packet, "socket:broadcast")
-			logger.Yellow(msg)
+			logger.Yellow("%s", msg)
 
 			return
 		}
 
-		exists, _ := lib.Exists(filepath.Join(command.Dst, command.Entry))
-		if exists {
-			rmrf := fmt.Sprintf("rm -rf \"%s\"", filepath.Join(command.Src, command.Entry))
-			operation.Line = fmt.Sprintf("Removing source %s", filepath.Join(command.Src, command.Entry))
+		operation.Line = fmt.Sprintf("Removing source %s", filepath.Join(command.Src, command.Entry))
+
+		packet := &domain.Packet{Topic: common.EventTransferProgress, Payload: operation}
+		c.ctx.Hub.Pub(packet, "socket:broadcast")
+
+		removed, pruned, err := removeTransferredSource(command, operation.OpKind == common.OpGatherMove)
+		if err != nil {
+			msg := fmt.Sprintf("Unable to remove source folder (%s): %s", filepath.Join(command.Src, command.Entry), err)
+			operation.Line = msg
 
 			packet := &domain.Packet{Topic: common.EventTransferProgress, Payload: operation}
 			c.ctx.Hub.Pub(packet, "socket:broadcast")
-			logger.Blue("removing:(%s)", rmrf)
 
-			err := lib.Shell(rmrf, "", func(line string) {
-				logger.Blue(line)
-			})
+			logger.Yellow("%s", msg)
+			return
+		}
 
-			if err != nil {
-				msg := fmt.Sprintf("Unable to remove source folder (%s): %s", filepath.Join(command.Src, command.Entry), err)
-				operation.Line = msg
-
-				packet := &domain.Packet{Topic: common.EventTransferProgress, Payload: operation}
-				c.ctx.Hub.Pub(packet, "socket:broadcast")
-
-				logger.Yellow(msg)
-			}
-
-			if operation.OpKind == common.OpGatherMove {
-				parent := filepath.Dir(command.Entry)
-				// if entry is a user share (tvshows), Dir returns ".", so we won't touch it
-				// if entry is a top-level children of a user share (tvshows/Billions), Dir returns "tvshows"
-				// if entry is a nested children (tvshows/Billions/Season 01), Dir returns "tvshows/Billions"
-				// in the first 2 cases no "/" is present in parent, so I won't prune them
-				if strings.Contains(parent, "/") {
-					rmdir := fmt.Sprintf(`find "%s" -type d -empty -prune -exec rm -rf {} \;`, filepath.Join(command.Src, parent))
-					operation.Line = fmt.Sprintf("Pruning parent %s", filepath.Join(command.Src, parent))
-
-					packet := &domain.Packet{Topic: common.EventTransferProgress, Payload: operation}
-					c.ctx.Hub.Pub(packet, "socket:broadcast")
-
-					logger.Blue("pruning:(%s)", rmdir)
-
-					err = lib.Shell(rmdir, "", func(line string) {
-						logger.Blue(line)
-					})
-
-					if err != nil {
-						msg := fmt.Sprintf("Unable to remove parent folder (%s): %s", filepath.Join(command.Src, parent), err)
-						operation.Line = msg
-
-						packet := &domain.Packet{Topic: common.EventTransferProgress, Payload: operation}
-						c.ctx.Hub.Pub(packet, "socket:broadcast")
-
-						logger.Yellow(msg)
-					}
-				} else {
-					logger.Yellow("skipping:prune:(%s)", filepath.Join(command.Src, parent))
-				}
-			}
-		} else {
-			logger.Yellow("skipping:deletion:(file/folder not present in destination):(%s)", filepath.Join(command.Dst, command.Entry))
+		logger.Blue("removed:(%s)", removed)
+		for _, parent := range pruned {
+			logger.Blue("pruned:(%s)", parent)
 		}
 	}
 }
@@ -405,7 +368,7 @@ func (c *Core) performRemoveSource(operation *domain.Operation, cmd *domain.Comm
 
 		text := "Removal completed"
 		operation.Line = text
-		logger.Blue(text)
+		logger.Blue("%s", text)
 
 		c.state.Unraid = c.refreshUnraid()
 		c.state.History.Items[operation.ID] = operation

--- a/daemon/services/core/safepath.go
+++ b/daemon/services/core/safepath.go
@@ -1,0 +1,220 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"unbalance/daemon/domain"
+)
+
+func cleanRoot(root string) (string, error) {
+	if root == "" {
+		return "", fmt.Errorf("empty root")
+	}
+
+	if !filepath.IsAbs(root) {
+		return "", fmt.Errorf("root must be absolute: %s", root)
+	}
+
+	return filepath.Clean(root), nil
+}
+
+func cleanEntry(entry string) (string, error) {
+	if entry == "" {
+		return "", fmt.Errorf("empty entry")
+	}
+
+	if filepath.IsAbs(entry) {
+		return "", fmt.Errorf("entry must be relative: %s", entry)
+	}
+
+	cleaned := filepath.Clean(entry)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("entry escapes root: %s", entry)
+	}
+
+	return cleaned, nil
+}
+
+func safeJoin(root, entry string) (string, string, error) {
+	cleanedRoot, err := cleanRoot(root)
+	if err != nil {
+		return "", "", err
+	}
+
+	cleanedEntry, err := cleanEntry(entry)
+	if err != nil {
+		return "", "", err
+	}
+
+	joined := filepath.Join(cleanedRoot, cleanedEntry)
+	if !pathIsInside(cleanedRoot, joined) {
+		return "", "", fmt.Errorf("path escapes root: %s", joined)
+	}
+
+	return joined, cleanedEntry, nil
+}
+
+func pathIsInside(root, target string) bool {
+	root = filepath.Clean(root)
+	target = filepath.Clean(target)
+
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func validateSymlinkBoundary(root, target string) error {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("unable to resolve root %s: %w", root, err)
+	}
+
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return fmt.Errorf("unable to resolve path %s: %w", target, err)
+	}
+
+	if !pathIsInside(resolvedRoot, resolvedTarget) {
+		return fmt.Errorf("path resolves outside root: %s", target)
+	}
+
+	return nil
+}
+
+type safeTransferPaths struct {
+	SrcRoot string
+	DstRoot string
+	Entry   string
+	SrcPath string
+	DstPath string
+}
+
+func safeCommandPaths(command *domain.Command) (safeTransferPaths, error) {
+	if command == nil {
+		return safeTransferPaths{}, fmt.Errorf("missing command")
+	}
+
+	srcPath, entry, err := safeJoin(command.Src, command.Entry)
+	if err != nil {
+		return safeTransferPaths{}, fmt.Errorf("invalid source path: %w", err)
+	}
+
+	dstPath, dstEntry, err := safeJoin(command.Dst, command.Entry)
+	if err != nil {
+		return safeTransferPaths{}, fmt.Errorf("invalid destination path: %w", err)
+	}
+
+	if entry != dstEntry {
+		return safeTransferPaths{}, fmt.Errorf("source and destination entries differ after cleaning")
+	}
+
+	srcRoot, _ := cleanRoot(command.Src)
+	dstRoot, _ := cleanRoot(command.Dst)
+	if srcRoot == dstRoot {
+		return safeTransferPaths{}, fmt.Errorf("source and destination roots must differ")
+	}
+
+	return safeTransferPaths{
+		SrcRoot: srcRoot,
+		DstRoot: dstRoot,
+		Entry:   entry,
+		SrcPath: srcPath,
+		DstPath: dstPath,
+	}, nil
+}
+
+func removeTransferredSource(command *domain.Command, pruneParents bool) (string, []string, error) {
+	paths, err := safeCommandPaths(command)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if _, err := os.Stat(paths.DstPath); err != nil {
+		if os.IsNotExist(err) {
+			return paths.SrcPath, nil, fmt.Errorf("destination is missing; refusing source deletion: %s", paths.DstPath)
+		}
+
+		return paths.SrcPath, nil, fmt.Errorf("unable to inspect destination %s: %w", paths.DstPath, err)
+	}
+
+	if err := validateSymlinkBoundary(paths.SrcRoot, paths.SrcPath); err != nil {
+		return paths.SrcPath, nil, err
+	}
+
+	if err := validateSymlinkBoundary(paths.DstRoot, paths.DstPath); err != nil {
+		return paths.SrcPath, nil, err
+	}
+
+	if err := os.RemoveAll(paths.SrcPath); err != nil {
+		return paths.SrcPath, nil, err
+	}
+
+	if !pruneParents {
+		return paths.SrcPath, nil, nil
+	}
+
+	pruned, err := pruneEmptyParents(paths.SrcRoot, paths.Entry)
+	return paths.SrcPath, pruned, err
+}
+
+func pruneEmptyParents(srcRoot, entry string) ([]string, error) {
+	root, err := cleanRoot(srcRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanedEntry, err := cleanEntry(entry)
+	if err != nil {
+		return nil, err
+	}
+
+	parentEntry := filepath.Dir(cleanedEntry)
+	// Preserve historical behavior: skip user shares and top-level share children.
+	if parentEntry == "." || !strings.Contains(parentEntry, string(filepath.Separator)) {
+		return nil, nil
+	}
+
+	parent := filepath.Join(root, parentEntry)
+	if !pathIsInside(root, parent) {
+		return nil, fmt.Errorf("parent escapes root: %s", parent)
+	}
+
+	pruned := make([]string, 0)
+	for pathIsInside(root, parent) && parent != root {
+		rel, relErr := filepath.Rel(root, parent)
+		if relErr != nil || rel == "." || !strings.Contains(rel, string(filepath.Separator)) {
+			break
+		}
+
+		if err := validateSymlinkBoundary(root, parent); err != nil {
+			return pruned, err
+		}
+
+		err := os.Remove(parent)
+		if err == nil {
+			pruned = append(pruned, parent)
+			parent = filepath.Dir(parent)
+			continue
+		}
+
+		if os.IsNotExist(err) {
+			parent = filepath.Dir(parent)
+			continue
+		}
+
+		if os.IsPermission(err) {
+			return pruned, err
+		}
+
+		// Non-empty directories stop pruning. This is expected and safe.
+		return pruned, nil
+	}
+
+	return pruned, nil
+}

--- a/daemon/services/core/safepath_test.go
+++ b/daemon/services/core/safepath_test.go
@@ -1,0 +1,182 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"unbalance/daemon/domain"
+)
+
+func TestSafeJoinRejectsEscapes(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "mnt", "disk1")
+
+	tests := []string{
+		"",
+		".",
+		"..",
+		"../disk2/share",
+		filepath.Join("..", "disk2", "share"),
+		filepath.Join(string(filepath.Separator), "mnt", "disk2", "share"),
+	}
+
+	for _, entry := range tests {
+		if _, _, err := safeJoin(root, entry); err == nil {
+			t.Fatalf("expected %q to be rejected", entry)
+		}
+	}
+}
+
+func TestSafeJoinAllowsRelativeEntries(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "mnt", "disk1")
+	path, entry, err := safeJoin(root, "share/movie/file.mkv")
+	if err != nil {
+		t.Fatalf("safeJoin returned error: %s", err)
+	}
+
+	want := filepath.Join(root, "share", "movie", "file.mkv")
+	if path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+	if entry != filepath.Join("share", "movie", "file.mkv") {
+		t.Fatalf("entry = %q", entry)
+	}
+}
+
+func TestRemoveTransferredSourceRemovesOnlyValidatedSource(t *testing.T) {
+	tmp := t.TempDir()
+	srcRoot := filepath.Join(tmp, "disk1")
+	dstRoot := filepath.Join(tmp, "disk2")
+	entry := filepath.Join("share", "movie")
+
+	mustMkdirAll(t, filepath.Join(srcRoot, entry))
+	mustWriteFile(t, filepath.Join(srcRoot, entry, "file.mkv"), "source")
+	mustMkdirAll(t, filepath.Join(dstRoot, entry))
+	mustWriteFile(t, filepath.Join(dstRoot, entry, "file.mkv"), "dest")
+
+	removed, pruned, err := removeTransferredSource(&domain.Command{
+		Src:   srcRoot,
+		Dst:   dstRoot,
+		Entry: entry,
+	}, true)
+	if err != nil {
+		t.Fatalf("removeTransferredSource returned error: %s", err)
+	}
+
+	if removed != filepath.Join(srcRoot, entry) {
+		t.Fatalf("removed = %q", removed)
+	}
+
+	if _, err := os.Stat(filepath.Join(srcRoot, entry)); !os.IsNotExist(err) {
+		t.Fatalf("source still exists or unexpected stat error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dstRoot, entry)); err != nil {
+		t.Fatalf("destination should remain: %s", err)
+	}
+
+	if len(pruned) != 0 {
+		t.Fatalf("top-level share parent should not be pruned, got %v", pruned)
+	}
+}
+
+func TestRemoveTransferredSourcePrunesNestedEmptyParents(t *testing.T) {
+	tmp := t.TempDir()
+	srcRoot := filepath.Join(tmp, "disk1")
+	dstRoot := filepath.Join(tmp, "disk2")
+	entry := filepath.Join("share", "show", "season", "episode.mkv")
+
+	mustMkdirAll(t, filepath.Dir(filepath.Join(srcRoot, entry)))
+	mustWriteFile(t, filepath.Join(srcRoot, entry), "source")
+	mustMkdirAll(t, filepath.Dir(filepath.Join(dstRoot, entry)))
+	mustWriteFile(t, filepath.Join(dstRoot, entry), "dest")
+
+	_, pruned, err := removeTransferredSource(&domain.Command{
+		Src:   srcRoot,
+		Dst:   dstRoot,
+		Entry: entry,
+	}, true)
+	if err != nil {
+		t.Fatalf("removeTransferredSource returned error: %s", err)
+	}
+
+	if len(pruned) == 0 {
+		t.Fatalf("expected nested empty parents to be pruned")
+	}
+
+	if _, err := os.Stat(filepath.Join(srcRoot, "share")); err != nil {
+		t.Fatalf("share boundary should remain: %s", err)
+	}
+}
+
+func TestRemoveTransferredSourceRefusesMissingDestination(t *testing.T) {
+	tmp := t.TempDir()
+	srcRoot := filepath.Join(tmp, "disk1")
+	dstRoot := filepath.Join(tmp, "disk2")
+	entry := filepath.Join("share", "movie")
+
+	mustMkdirAll(t, filepath.Join(srcRoot, entry))
+	mustMkdirAll(t, dstRoot)
+
+	_, _, err := removeTransferredSource(&domain.Command{
+		Src:   srcRoot,
+		Dst:   dstRoot,
+		Entry: entry,
+	}, false)
+	if err == nil {
+		t.Fatalf("expected missing destination to be rejected")
+	}
+
+	if _, statErr := os.Stat(filepath.Join(srcRoot, entry)); statErr != nil {
+		t.Fatalf("source should remain after refused delete: %s", statErr)
+	}
+}
+
+func TestRemoveTransferredSourceRefusesSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior differs on windows")
+	}
+
+	tmp := t.TempDir()
+	srcRoot := filepath.Join(tmp, "disk1")
+	dstRoot := filepath.Join(tmp, "disk2")
+	outside := filepath.Join(tmp, "outside")
+	entry := filepath.Join("share", "escape")
+
+	mustMkdirAll(t, filepath.Join(srcRoot, "share"))
+	mustMkdirAll(t, filepath.Join(dstRoot, entry))
+	mustMkdirAll(t, outside)
+	mustWriteFile(t, filepath.Join(outside, "file.txt"), "outside")
+
+	if err := os.Symlink(outside, filepath.Join(srcRoot, entry)); err != nil {
+		t.Fatalf("unable to create symlink: %s", err)
+	}
+
+	_, _, err := removeTransferredSource(&domain.Command{
+		Src:   srcRoot,
+		Dst:   dstRoot,
+		Entry: entry,
+	}, false)
+	if err == nil {
+		t.Fatalf("expected symlink escape to be rejected")
+	}
+
+	if _, statErr := os.Stat(filepath.Join(outside, "file.txt")); statErr != nil {
+		t.Fatalf("outside target should remain: %s", statErr)
+	}
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %s", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %s", path, err)
+	}
+}

--- a/docs/security-executor-boundary.md
+++ b/docs/security-executor-boundary.md
@@ -1,0 +1,243 @@
+# Executor boundary details
+
+Branch: `security/root-runtime-review`
+
+This expands the proposed phase 1 work: create an internal filesystem executor boundary before splitting into separate web/worker processes.
+
+## 1. `filesystem.Executor` boundary
+
+The first refactor should make privileged filesystem actions explicit behind an interface.
+
+Example shape:
+
+```go
+type Executor interface {
+    StorageStatus(ctx context.Context) (*domain.Unraid, error)
+    ListTree(ctx context.Context, req ListTreeRequest) (domain.Branch, error)
+    Locate(ctx context.Context, req LocateRequest) ([]string, error)
+    ScanItems(ctx context.Context, req ScanItemsRequest) (*ScanItemsResult, error)
+    ExecuteTransfer(ctx context.Context, req TransferRequest, events chan<- TransferEvent) (*TransferResult, error)
+    ValidateTransfer(ctx context.Context, req TransferRequest, events chan<- TransferEvent) (*TransferResult, error)
+    RemoveSource(ctx context.Context, req RemoveSourceRequest) error
+    Stop(ctx context.Context, operationID string) error
+}
+```
+
+Initially this can be an in-process implementation using the existing `os`, `find`, `du`, and `rsync` logic. Later the same interface can be backed by a Unix-socket worker client.
+
+The important win is architectural: core/web code stops directly shelling out or deleting paths.
+
+## 2. Move semantics: copy first, then guarded delete
+
+A move plan should remain logically the same:
+
+```text
+1. rsync/copy source entry to destination
+2. verify copy completed acceptably
+3. delete only the exact source entry that was copied
+4. optionally prune empty parents, bounded by safety rules
+```
+
+What changes is where the delete authority lives and how it is validated.
+
+### Current shape
+
+Current code effectively does:
+
+```text
+rsync src/entry dst/
+if dst/entry exists:
+    shell: rm -rf src/entry
+    maybe shell: find parent -type d -empty -prune -exec rm -rf {}
+```
+
+### Safer shape
+
+The executor/worker receives a structured command:
+
+```go
+type TransferCommand struct {
+    ID       string
+    SrcRoot  string // e.g. /mnt/disk1
+    DstRoot  string // e.g. /mnt/disk2
+    Entry    string // e.g. media/movie/file.mkv, always relative
+    Mode     TransferMode // Copy or Move
+    RsyncArgs []string
+}
+```
+
+For `ModeMove`, the executor runs:
+
+```text
+safeSrc = validateJoin(SrcRoot, Entry)
+safeDst = validateJoin(DstRoot, Entry)
+run rsync safeSrc -> DstRoot
+if rsync success or acceptable partial status:
+    verify safeDst exists
+    remove safeSrc only if it still validates and matches the completed command
+    prune empty parents upward, stopping before SrcRoot/share boundary
+```
+
+So deletion is not a separate browser-triggered “delete this path” ability. It is a postcondition of a specific completed transfer command.
+
+### Important delete rules
+
+For move deletion:
+
+- delete only after the matching transfer completes;
+- delete only `SrcRoot + Entry`, never arbitrary client paths;
+- revalidate immediately before deletion;
+- refuse `Entry` values that are absolute, empty, `.`, `..`, or escape via `..`;
+- refuse source roots outside discovered array disks;
+- refuse destination roots outside discovered array disks;
+- refuse same source/destination root;
+- do not follow symlink escapes for destructive deletion;
+- if verification is uncertain, skip delete and flag the command.
+
+This preserves current move behavior while tightening the authority boundary.
+
+## 3. Replacing shell deletion with Go deletion
+
+Instead of building shell strings like:
+
+```bash
+rm -rf "/mnt/disk1/share/item"
+find "/mnt/disk1/share/parent" -type d -empty -prune -exec rm -rf {} \;
+```
+
+use guarded Go functions.
+
+Example sketch:
+
+```go
+func RemoveTransferredSource(cmd TransferCommand, roots AllowedRoots) error {
+    src, err := ValidateEntryPath(roots, cmd.SrcRoot, cmd.Entry)
+    if err != nil {
+        return err
+    }
+
+    dst, err := ValidateEntryPath(roots, cmd.DstRoot, cmd.Entry)
+    if err != nil {
+        return err
+    }
+
+    if !Exists(dst) {
+        return fmt.Errorf("destination is missing; refusing source deletion")
+    }
+
+    if IsUnsafeRemovalTarget(src, cmd.SrcRoot) {
+        return fmt.Errorf("unsafe removal target")
+    }
+
+    return os.RemoveAll(src)
+}
+```
+
+Parent pruning should be intentionally conservative:
+
+```go
+func PruneEmptyParents(srcRoot, entry string) {
+    parent := filepath.Dir(filepath.Join(srcRoot, entry))
+
+    for isBelowBoundary(parent, srcRoot) {
+        err := os.Remove(parent) // succeeds only if empty
+        if err != nil {
+            return
+        }
+        parent = filepath.Dir(parent)
+    }
+}
+```
+
+Use `os.Remove`, not `os.RemoveAll`, for parent pruning. That way non-empty directories are naturally preserved.
+
+The result is safer than shelling out because:
+
+- no shell parser;
+- no command injection class;
+- easier boundary checks;
+- easier unit tests;
+- clearer audit logs;
+- no accidental broad `rm -rf` string construction.
+
+## 4. Server-side IDs instead of executable browser payloads
+
+The browser should not be trusted to send executable operations.
+
+### Current risk
+
+Some flows accept an entire `Operation` or `Command` object from the browser/websocket. Those objects contain fields that can affect filesystem behavior:
+
+- `Src`
+- `Dst`
+- `Entry`
+- `RsyncArgs`
+- `OpKind`
+
+Even with auth, the browser is the least trusted part of the system. It should display and confirm plans, not define executable paths.
+
+### Safer model
+
+The server creates and stores immutable plans.
+
+```go
+type StoredPlan struct {
+    ID        string
+    Kind      OperationKind
+    CreatedAt time.Time
+    Commands  []TransferCommand
+    Summary   PlanSummary
+    State     PlanState
+}
+```
+
+Flow:
+
+```text
+Browser -> web: plan request { source, targets, selected folders }
+Web/core: normalizes + validates request
+Web/core: creates StoredPlan with server-generated commands
+Web -> browser: display plan summary + planID
+Browser -> web: execute { planID }
+Web: loads StoredPlan(planID)
+Web -> executor: ExecuteTransfer(storedPlan.Commands)
+```
+
+For individual source removal after a flagged or manual flow:
+
+```text
+Browser -> web: removeSource { planID, commandID }
+Web: finds exact stored command
+Web: verifies command status allows removal
+Web -> executor: RemoveSource(storedCommand)
+```
+
+For replay:
+
+```text
+Browser -> web: replay { historyOperationID }
+Web: loads server-side history record
+Web: creates new StoredPlan from that trusted record after revalidation
+Web -> browser: shows revalidated plan
+Browser -> web: execute { newPlanID }
+```
+
+This means a malicious browser cannot invent:
+
+```json
+{ "src": "/", "entry": "boot", "dst": "/mnt/disk1" }
+```
+
+because the server never executes browser-provided `src/dst/entry`. It only executes commands it created and stored.
+
+## Practical first PR scope
+
+A good first PR could be small and still valuable:
+
+1. Add `daemon/services/filesystem` or `daemon/services/executor` package.
+2. Add path validation helpers + tests.
+3. Move source deletion/pruning behind executor functions.
+4. Replace shell `rm -rf` and shell parent pruning with guarded Go code.
+5. Leave process model unchanged.
+
+Then a second PR can tackle server-side `planID` execution.

--- a/docs/security-runtime-review.md
+++ b/docs/security-runtime-review.md
@@ -177,4 +177,3 @@ Given Unraid constraints, the worker split is probably more realistic than tryin
 3. Replace shell deletion with validated Go deletion/pruning.
 4. Change websocket command payloads to use IDs rather than full executable `Operation` objects for execute/replay/remove-source.
 5. Then evaluate a privileged-worker split once the trust boundary is explicit.
-

--- a/docs/security-runtime-review.md
+++ b/docs/security-runtime-review.md
@@ -1,0 +1,180 @@
+# Security runtime review: root process on Unraid
+
+Branch: `security/root-runtime-review`
+
+## Context
+
+`unbalanced` currently performs filesystem scans and transfers across `/mnt/*` disks/shares. On Unraid this often means running with broad privileges, sometimes as `root`, because ownership and permissions across user shares/disks can block a plain `nobody` process.
+
+The security goal should not be "never root" at all costs. The practical goal is: **keep the web/API/control plane as low-privilege as possible, and make every privileged filesystem action narrow, validated, auditable, and intentional.**
+
+## Current high-risk architecture points
+
+### 1. Web server and transfer executor live in the same privileged process
+
+The Echo HTTP server, websocket command handler, planner, rsync launcher, source deletion, history, auth/session handling, and config writes all run inside the same binary/process.
+
+If that process is running as `root`, then a bug in any HTTP/auth/websocket/config path becomes a root-level file operation risk.
+
+Relevant code:
+
+- `daemon/services/server/server.go` starts the HTTP server and registers the API/websocket endpoints.
+- `daemon/services/core/core.go` consumes websocket packets and starts scatter/gather/move/replay/remove operations.
+- `daemon/services/core/operation.go` executes rsync and source deletion.
+
+### 2. Websocket command channel is powerful
+
+The websocket accepts command packets and publishes them directly into the core mailbox. Auth/CSRF/origin checks exist when auth is enabled, which is good, but the command payload itself is trusted after decoding.
+
+Risk: if an attacker gets a session, if auth is disabled, or if a future endpoint bypasses checks, the websocket can trigger transfer/delete operations.
+
+Concrete sensitive commands:
+
+- `scatter:move`
+- `gather:move`
+- `remove:source`
+- `replay`
+
+### 3. Client-supplied operation/command replay can cross trust boundaries
+
+Some command paths accept a full `domain.Operation` or `domain.Command` from the client/websocket and use its fields later for rsync/deletion.
+
+Relevant code:
+
+- `CommandScatterValidate` accepts `domain.Operation` and reuses `original.Commands`.
+- `CommandRemoveSource` accepts `Operation` + `Command` from the client.
+- `CommandReplay` accepts `domain.Operation` from the client.
+
+That means fields like `Src`, `Dst`, `Entry`, `RsyncArgs`, and `OpKind` should be treated as untrusted. Today they are not strongly revalidated against a server-created plan/history entry before execution.
+
+### 4. Source deletion uses shell commands
+
+`handleItemDeletion` builds shell commands:
+
+- `rm -rf "<source/entry>"`
+- `find "<parent>" -type d -empty -prune -exec rm -rf {} \;`
+
+Quoting helps but does not fully remove shell risk. More importantly, `rm -rf` is high-impact when running as root. This should move to Go filesystem calls with strict path validation and symlink/path-boundary checks.
+
+### 5. Planner paths are only partially normalized
+
+API tree/locate paths are normalized under `/mnt`, which is good, but operation paths later come from plan/operation structures and should be rechecked at execution time.
+
+A safe execution layer should require:
+
+- `Src` resolves under `/mnt/disk*` or another explicitly allowed Unraid disk root.
+- `Dst` resolves under `/mnt/disk*`.
+- `Entry` is relative, clean, non-empty, not `.` or `..`, and does not escape when joined.
+- resolved source/destination are not symlinks escaping the allowed roots.
+- source deletion only touches the exact source path that was transferred.
+
+### 6. `rsyncArgs` is user-configurable and flows into execution
+
+`RsyncArgs` is set from config and appended into rsync execution. It is passed as argv, not shell-concatenated, which is good. Still, because rsync supports dangerous options (`--delete`, `--remove-source-files`, `--rsync-path`, remote syntax, etc.), the app should validate or constrain custom args.
+
+This is especially important if the process runs as root.
+
+### 7. Global CORS is open by default
+
+`middleware.CORS()` is enabled with defaults. CSRF and SameSite help for authenticated mutations, and websocket origin is checked when auth is enabled. Still, the app should prefer a same-origin CORS policy by default, especially for a local root-capable service.
+
+### 8. Default auth can be disabled
+
+Auth support has improved, but `AUTH_ENABLED=false` remains the default. In a trusted LAN appliance this may be acceptable historically, but for a root-capable file mover, the safer posture is:
+
+- make auth strongly recommended in UI/docs;
+- warn loudly when disabled;
+- require explicit opt-out for dangerous operations when unauthenticated; or
+- consider enabling auth by default for new installs while preserving upgrades.
+
+## Best improvement opportunities
+
+### P1: Introduce a server-side operation capability model
+
+Do not let client-submitted `Operation` / `Command` objects directly drive execution.
+
+Recommended shape:
+
+1. Planning creates a server-side `planID` and stores the immutable normalized command list in memory/history.
+2. The UI can request `execute(planID)` / `validate(planID)` / `removeSource(commandID)`.
+3. The server looks up the original plan/command and executes only that stored version.
+4. Any replay from history should rehydrate a stored server history item, not trust client-sent paths/args.
+
+This is the cleanest architectural security win.
+
+### P1: Add a path safety package and enforce it at execution time
+
+Create a small package/function set responsible for validating execution paths before every rsync/delete:
+
+- allowed roots from current Unraid disk discovery, not hardcoded strings only;
+- clean relative entries;
+- no absolute `Entry`;
+- no `..` escape;
+- symlink escape detection where possible;
+- source/destination must be different roots;
+- deletion must validate again immediately before removal.
+
+This should be applied in `runCommand`, `handleItemDeletion`, `removeSource`, `replay`, and validate paths.
+
+### P1: Replace shell-based deletion with safe Go deletion primitives
+
+Replace `rm -rf` shell execution with guarded Go code:
+
+- `os.Remove` for files;
+- `os.RemoveAll` only after safe path validation and maybe refusing root-ish paths;
+- parent pruning via walking upward and `os.Remove` only empty directories, stopping before share/disk boundary.
+
+This removes shell injection risk and gives better guardrails/logging.
+
+### P2: Split low-privilege UI/API from privileged worker
+
+Longer-term architecture:
+
+- web/API process runs as `nobody`;
+- a small local privileged worker performs only validated filesystem actions;
+- communication over a Unix socket with file permissions, or a very small localhost-only RPC;
+- commands are structured, not shell strings;
+- worker owns path validation and audit logging.
+
+This is more work, but it materially reduces blast radius. Even if the worker remains root, the attack surface that is root-capable becomes much smaller.
+
+### P2: Constrain `rsyncArgs`
+
+Adopt an allowlist/denylist policy for custom rsync args.
+
+At minimum, block or warn on:
+
+- remote execution/transport options;
+- `--delete*` unless explicitly supported;
+- `--remove-source-files`;
+- options that invoke external programs;
+- options that mutate ownership/perms beyond expected behavior.
+
+Also store parsed args as structured tokens; avoid round-tripping through `RsyncStrArgs` except for display.
+
+### P2: Harden HTTP defaults
+
+- Replace default open CORS with same-origin/no CORS unless dev mode is enabled.
+- Add security headers (`X-Content-Type-Options`, `Referrer-Policy`, conservative CSP where compatible).
+- Warn in UI when auth is disabled.
+- Consider shorter sessions than 180 days or configurable session duration.
+- Ensure session files and env files are written with restrictive permissions where Unraid permits it.
+
+### P3: Privilege drop / staged privilege approach
+
+If Unraid allows it, start as root only to bind/read what is needed, then drop privileges for the web process. For transfers that need elevated permissions, use one of:
+
+- a root worker;
+- controlled `sudo` rules for rsync/delete only;
+- Linux capabilities where applicable, although file ownership/permission bypass usually still needs broad privileges.
+
+Given Unraid constraints, the worker split is probably more realistic than trying to perfect `nobody` permissions globally.
+
+## Suggested first implementation path
+
+1. Add `daemon/services/core/safepath.go` with validation helpers and tests.
+2. Enforce safe paths in `createScatterOperation`, `createGatherOperation`, `runCommand`, and `handleItemDeletion`.
+3. Replace shell deletion with validated Go deletion/pruning.
+4. Change websocket command payloads to use IDs rather than full executable `Operation` objects for execute/replay/remove-source.
+5. Then evaluate a privileged-worker split once the trust boundary is explicit.
+

--- a/docs/security-worker-split.md
+++ b/docs/security-worker-split.md
@@ -1,0 +1,324 @@
+# Privileged worker split design
+
+Branch: `security/root-runtime-review`
+
+## Goal
+
+Reduce the blast radius of running `unbalanced` on Unraid when filesystem operations require root-like privileges.
+
+Instead of one root process serving HTTP, handling auth/session state, parsing websocket commands, planning operations, and executing file moves/deletes, split the system into:
+
+1. **UI/API daemon** — low privilege, ideally `nobody`.
+2. **Filesystem worker** — small privileged process with a narrow command surface.
+
+The goal is not to magically avoid privilege. The goal is to make the root-capable part tiny, boring, validated, and auditable.
+
+## High-level architecture
+
+```text
+Browser
+  |
+  | HTTP/WebSocket
+  v
+unbalanced-web  -- Unix socket / local RPC -->  unbalanced-worker
+(nobody)                                      (root or elevated)
+  |                                               |
+  | auth, sessions, UI, planning                  | validated stat/scan/rsync/delete only
+  | operation state, history                      | no HTTP, no browser input, no config UI
+  v                                               v
+/boot/config/plugins/unbalanced            /mnt/disk*, /mnt/user as needed
+```
+
+## Process responsibilities
+
+### `unbalanced-web` low-privilege process
+
+Runs as `nobody` where possible.
+
+Owns:
+
+- HTTP server
+- embedded UI assets
+- auth/session/CSRF
+- websocket connection to browser
+- config UI and non-secret config state
+- operation state shown to the frontend
+- high-level planning flow
+- user confirmation flow
+- history presentation
+- worker client
+
+Does **not** directly:
+
+- shell out to `rsync`
+- remove files/folders
+- walk arbitrary root-owned trees unless permissions allow
+- trust browser-supplied executable `Operation` objects
+
+### `unbalanced-worker` privileged process
+
+Runs as root, or with the minimum privilege Unraid realistically allows.
+
+Owns only filesystem capability:
+
+- discover disks/shares
+- stat/read directory metadata needed for planning
+- calculate item sizes when low-privilege process cannot
+- execute `rsync` with validated args
+- remove exact transferred source paths
+- prune empty parent directories within validated boundaries
+- stream progress/events back to web process
+
+Does **not** expose HTTP.
+Does **not** parse browser sessions/cookies.
+Does **not** accept raw shell commands.
+Does **not** accept arbitrary absolute paths without validation.
+
+## Communication channel
+
+Recommended first version: Unix domain socket.
+
+Example path:
+
+```text
+/var/run/unbalanced/worker.sock
+```
+
+Permissions:
+
+```text
+owner: root
+ group: nobody/users or dedicated unbalanced group
+ mode: 0660
+```
+
+The worker should reject requests from unexpected peers if peer credential checks are available. On Linux, Go can inspect Unix socket peer credentials via `SO_PEERCRED`.
+
+If Unraid makes socket permissions awkward, a localhost-only TCP socket with a boot-generated shared token is possible, but Unix socket is cleaner.
+
+## RPC shape
+
+Keep the protocol structured and boring. JSON over Unix socket is enough initially; gRPC is probably overkill.
+
+Suggested request model:
+
+```go
+type WorkerRequest struct {
+    ID      string          `json:"id"`
+    Method  string          `json:"method"`
+    Payload json.RawMessage `json:"payload"`
+}
+
+type WorkerResponse struct {
+    ID      string          `json:"id"`
+    OK      bool            `json:"ok"`
+    Error   string          `json:"error,omitempty"`
+    Payload json.RawMessage `json:"payload,omitempty"`
+}
+```
+
+Suggested methods:
+
+- `StorageStatus`
+- `ListTree`
+- `LocatePath`
+- `ScanItems`
+- `PlanStats`
+- `ExecuteRsync`
+- `ValidateRsync`
+- `RemoveTransferredSource`
+- `StopOperation`
+
+For long-running work, either:
+
+1. request starts a job and returns `jobID`, then web subscribes to progress; or
+2. one streaming connection emits progress events until completion.
+
+Simpler first version: keep one worker connection open and stream newline-delimited JSON events.
+
+## Command model
+
+Avoid client-submitted executable operations.
+
+Current-ish flow:
+
+```text
+browser sends full Operation/Command-ish payload
+server executes fields from payload
+```
+
+Safer flow:
+
+```text
+browser selects folders/targets
+web asks worker/web planner for plan
+web stores immutable server-side plan as planID
+browser confirms planID
+web asks worker to execute planID's stored commands
+worker validates every command again before execution
+```
+
+The browser should never be the source of truth for:
+
+- `Src`
+- `Dst`
+- `Entry`
+- `RsyncArgs`
+- deletion target
+- operation kind
+
+## Path validation boundary
+
+The worker owns final validation because it is the privileged side.
+
+Every executable command should pass through a single validator:
+
+```go
+type SafeCommand struct {
+    SrcDiskRoot string
+    DstDiskRoot string
+    Entry       string
+    Args        []string
+}
+```
+
+Validation rules:
+
+- source root must be one of current discovered disk roots, e.g. `/mnt/disk1`
+- destination root must be one of current discovered disk roots
+- source and destination roots must differ
+- `Entry` must be relative, clean, non-empty, not `.`, not `..`
+- joined source path must remain inside source root
+- joined destination path must remain inside destination root
+- no remote rsync syntax in source/destination
+- rsync args must pass allow/deny policy
+- deletion target must exactly match a completed transfer source
+- parent pruning must stop before disk root/share boundary
+- symlink handling should refuse or explicitly resolve escapes before destructive actions
+
+## Worker install/start model on Unraid
+
+There are two practical options.
+
+### Option A: one binary, two modes
+
+Build one `unbalanced` binary with subcommands/modes:
+
+```bash
+unbalanced web --port 7090 --worker-socket /var/run/unbalanced/worker.sock
+unbalanced worker --socket /var/run/unbalanced/worker.sock
+```
+
+Pros:
+
+- less packaging complexity
+- shared code/types
+- easiest migration path
+
+Cons:
+
+- need discipline to keep worker imports/surface small
+
+### Option B: two binaries
+
+```bash
+unbalanced-web
+unbalanced-worker
+```
+
+Pros:
+
+- stronger conceptual separation
+- easier to audit what the worker can do
+
+Cons:
+
+- more packaging/release complexity
+
+Recommendation: **start with Option A** using internal packages that enforce separation. If it feels clean, split binaries later.
+
+## Start script shape
+
+Current script starts the app through `sudo -H bash -c ...`.
+
+A split version could look like:
+
+```bash
+# start privileged worker as root
+nohup "$prog" worker \
+  --socket /var/run/unbalanced/worker.sock \
+  >> /var/log/unbalanced-worker.log 2>&1 &
+
+# start low-privilege web process
+nohup sudo -u nobody -H "$prog" web \
+  --port "$PORT" \
+  --worker-socket /var/run/unbalanced/worker.sock \
+  >> /var/log/unbalanced-web.log 2>&1 &
+```
+
+Unraid specifics may require using the available `sudo`/`su`/`runuser` behavior. The important piece is: only the worker stays privileged.
+
+## Migration strategy
+
+### Phase 1: draw the boundary without changing processes
+
+- Create a `filesystem.Executor` interface.
+- Move rsync/delete/tree/stat calls behind that interface.
+- Add central path validation.
+- Keep everything in one process initially.
+
+This gives security value immediately and makes tests possible.
+
+### Phase 2: local in-process worker implementation
+
+- Make core call an executor that looks like a worker client.
+- Use server-side plan IDs and immutable command records.
+- Stop accepting executable `Operation` objects from browser payloads.
+
+### Phase 3: Unix socket worker
+
+- Add `unbalanced worker` mode.
+- Add `unbalanced web` mode.
+- Replace in-process executor with Unix socket RPC client.
+- Keep a compatibility mode for old single-process startup if needed.
+
+### Phase 4: harden worker
+
+- Peer credential check.
+- Worker method allowlist.
+- Strict rsync arg policy.
+- Audit log of every privileged action.
+- Optional operation confirmation token: worker executes only commands minted by web-side planner and signed/HMACed with a boot secret.
+
+## Main tradeoffs
+
+### Benefits
+
+- HTTP/auth/UI bugs no longer directly equal root filesystem control.
+- Privileged code surface becomes much smaller.
+- Easier to audit destructive operations.
+- Creates a natural place for path and rsync policy enforcement.
+- Makes future sandboxing/capability work easier.
+
+### Costs
+
+- More process lifecycle complexity.
+- More error states: worker missing, socket permission issue, worker restart during operation.
+- Need progress streaming across process boundary.
+- Some planning scans may still require worker privileges, so the boundary must be designed carefully.
+
+## Open questions
+
+- Can Unraid reliably run the web process as `nobody` from plugin scripts?
+- Which user/group should own `/var/run/unbalanced/worker.sock`?
+- Should planning scans run in the worker, or only execution/deletion?
+- Should auth become required when privileged worker mode is enabled?
+- How much backward compatibility is needed for single-process mode?
+
+## Recommendation
+
+Do this incrementally.
+
+First implement the **executor boundary + server-side plan IDs + path validation** while still running as one process. That reduces risk immediately and avoids a large risky rewrite.
+
+Then introduce the worker mode once the internal boundary is clean.


### PR DESCRIPTION
## Summary
- replace shell-based source deletion after move with guarded Go filesystem deletion
- validate source/destination roots and relative entries before deletion
- refuse missing destinations and symlink/path escapes before removing source data
- add focused unit coverage for safepath/source deletion behavior
- document the current root-runtime risk model and safer future worker split

## Validation
- `git diff --check`
- `GOOS=linux GOARCH=amd64 go test -c ./daemon/services/core -o /tmp/unbalance-core-linux.test`
- copied the compiled Linux test binary to `hal` and ran `/tmp/unbalance-core-linux.test -test.v` — all 6 safepath/source deletion tests passed
- `cd ui && npm run build`
- `GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=2026.05.02-0d1d9a7" -v -o unbalanced .`
- smoke-tested the Linux binary on `hal` with `--help`
- contained integration test on `hal` using `/mnt/disk1/testing` and `/mnt/disk2/testing` as roots:
  - started locally-built binary on port `17090`
  - sent websocket `replay` move for `unbalance-it-20260502-145207-185968/move-me`
  - verified rsync exit code 0, source move dir removed, destination payload remained, sentinels remained
  - guarded-cleaned only the unique test fixture

## Notes
- macOS native `go test ./...` still hits an existing Darwin/Linux type mismatch in `daemon/services/core/array.go`; validation here used Linux-targeted build/test execution because the plugin runs on Unraid/Linux.
