### PR TITLE
Use ID-based websocket execution commands

### DIFF
--- a/daemon/domain/plan.go
+++ b/daemon/domain/plan.go
@@ -13,6 +13,7 @@ import (
 // OpScatterPlan
 // OpGatherPlan
 type Plan struct {
+	ID      string    `json:"id"`
 	Started time.Time `json:"started"`
 	Ended   time.Time `json:"ended"`
 

--- a/daemon/services/core/core.go
+++ b/daemon/services/core/core.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sync"
 	"time"
 
 	"github.com/teris-io/shortid"
@@ -62,6 +63,9 @@ type Core struct {
 
 	mailbox chan any
 
+	pendingPlans   map[string]*planTicket
+	pendingPlansMu sync.Mutex
+
 	stopped bool
 }
 
@@ -72,6 +76,7 @@ func Create(ctx *domain.Context) *Core {
 		state: &domain.State{
 			Status: common.OpNeutral,
 		},
+		pendingPlans: make(map[string]*planTicket),
 		mailbox: ctx.Hub.Sub(
 			common.CommandScatterPlanStart,
 			common.CommandScatterMove,
@@ -142,22 +147,21 @@ func (c *Core) mailboxHandler() {
 			}
 			go c.scatterPlanPrepare(setup)
 		case common.CommandScatterMove:
-			var plan domain.Plan
-			err := lib.Bind(packet.Payload, &plan)
+			var ref planRef
+			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
 				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
 				continue
 			}
-			logger.Olive("%+v", plan)
-			go c.scatterMove(plan)
+			go c.scatterMove(ref.PlanID)
 		case common.CommandScatterCopy:
-			var plan domain.Plan
-			err := lib.Bind(packet.Payload, &plan)
+			var ref planRef
+			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
 				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
 				continue
 			}
-			go c.scatterCopy(plan)
+			go c.scatterCopy(ref.PlanID)
 
 		case common.CommandGatherPlanStart:
 			var setup domain.GatherSetup
@@ -169,44 +173,41 @@ func (c *Core) mailboxHandler() {
 			go c.gatherPlanPrepare(setup)
 
 		case common.CommandGatherMove:
-			var plan domain.Plan
-			err := lib.Bind(packet.Payload, &plan)
+			var ref planRef
+			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
 				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
 				continue
 			}
-			go c.gatherMove(plan)
+			go c.gatherMove(ref.PlanID, ref.Target)
 
 		case common.CommandScatterValidate:
-			var operation domain.Operation
-			err := lib.Bind(packet.Payload, &operation)
+			var ref operationRef
+			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
 				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
 				continue
 			}
-			go c.scatterValidate(operation)
+			go c.scatterValidate(ref.OperationID)
 
 		case common.CommandRemoveSource:
-			var params struct {
-				Operation *domain.Operation `json:"operation"`
-				Command   *domain.Command   `json:"command"`
-			}
-			err := lib.Bind(packet.Payload, &params)
+			var ref commandRef
+			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
 				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
 				continue
 			}
-			go c.removeSource(params.Operation, params.Command)
+			go c.removeSourceByID(ref.OperationID, ref.CommandID)
 
 		case common.CommandReplay:
-			var operation domain.Operation
-			err := lib.Bind(packet.Payload, &operation)
+			var ref operationRef
+			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
 				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
 				continue
 			}
 
-			go c.replay(operation)
+			go c.replay(ref.OperationID)
 
 		case common.CommandStop:
 			c.stopped = true

--- a/daemon/services/core/gather.go
+++ b/daemon/services/core/gather.go
@@ -46,7 +46,6 @@ func (c *Core) gatherPlanPrepare(setup domain.GatherSetup) {
 
 func (c *Core) gatherPlan(plan *domain.Plan) {
 	c.gatherPlanStart(plan)
-	c.gatherPlanEnd(plan)
 }
 
 func (c *Core) gatherPlanStart(plan *domain.Plan) {
@@ -115,7 +114,14 @@ func (c *Core) gatherPlanStart(plan *domain.Plan) {
 func (c *Core) gatherPlanEnd(plan *domain.Plan) {
 	c.state.Status = common.OpNeutral
 
-	packet := &domain.Packet{Topic: common.EventGatherPlanEnded, Payload: plan}
+	planView, err := c.storePendingPlan(planFlowGather, plan)
+	if err != nil {
+		logger.Red("unable to store gather plan: %s", err)
+		c.publishOperationError("unable to store gather plan: %s", err)
+		return
+	}
+
+	packet := &domain.Packet{Topic: common.EventGatherPlanEnded, Payload: planView}
 	c.ctx.Hub.Pub(packet, "socket:broadcast")
 
 	// TODO: finish this implementation
@@ -128,7 +134,25 @@ func (c *Core) gatherPlanEnd(plan *domain.Plan) {
 }
 
 // // GATHER TRANSFER
-func (c *Core) gatherMove(plan domain.Plan) {
+func (c *Core) gatherMove(planID, target string) {
+	plan, err := c.takePendingPlan(planID, planFlowGather)
+	if err != nil {
+		logger.Yellow("gatherMove: %s", err)
+		c.publishOperationError("unable to start gather move: %s", err)
+		return
+	}
+	if target == "" {
+		logger.Yellow("gatherMove: missing target")
+		c.publishOperationError("unable to start gather move: missing target")
+		return
+	}
+	if _, ok := plan.VDisks[target]; !ok {
+		logger.Yellow("gatherMove: invalid target %s", target)
+		c.publishOperationError("unable to start gather move: invalid target")
+		return
+	}
+	plan.Target = target
+
 	c.state.Status = common.OpGatherMove
 	c.state.Unraid = c.refreshUnraid()
 	c.state.Operation = c.createGatherOperation(plan)
@@ -155,9 +179,15 @@ func (c *Core) createGatherOperation(plan domain.Plan) *domain.Operation {
 
 	for _, disk := range c.state.Unraid.Disks {
 		vdisk := plan.VDisks[disk.Path]
+		if vdisk == nil {
+			continue
+		}
 
 		// only one disk will be destination (target)
 		if vdisk.Path != plan.Target {
+			continue
+		}
+		if vdisk.Bin == nil {
 			continue
 		}
 

--- a/daemon/services/core/operation.go
+++ b/daemon/services/core/operation.go
@@ -337,12 +337,26 @@ func (c *Core) endOperation(subject, headline string, commands []string, operati
 	logger.Blue("\n%s\n%s", subject, message)
 }
 
-func (c *Core) removeSource(operation *domain.Operation, command *domain.Command) {
+func (c *Core) removeSourceByID(operationID, commandID string) {
+	operation, err := c.historyOperation(operationID)
+	if err != nil {
+		logger.Yellow("removeSource: %s", err)
+		c.publishOperationError("unable to remove source: %s", err)
+		return
+	}
+
+	command, err := findCommand(&operation, commandID)
+	if err != nil {
+		logger.Yellow("removeSource: %s", err)
+		c.publishOperationError("unable to remove source: %s", err)
+		return
+	}
+
 	c.state.Status = operation.OpKind
-	c.state.Operation = operation
+	c.state.Operation = &operation
 	c.state.Unraid = c.refreshUnraid()
 
-	go c.performRemoveSource(operation, command)
+	go c.performRemoveSource(&operation, command)
 }
 
 func (c *Core) performRemoveSource(operation *domain.Operation, cmd *domain.Command) {
@@ -396,7 +410,14 @@ func (c *Core) performRemoveSource(operation *domain.Operation, cmd *domain.Comm
 	}
 }
 
-func (c *Core) replay(operation domain.Operation) {
+func (c *Core) replay(operationID string) {
+	operation, err := c.historyOperation(operationID)
+	if err != nil {
+		logger.Yellow("replay: %s", err)
+		c.publishOperationError("unable to replay operation: %s", err)
+		return
+	}
+
 	c.state.Status = operation.OpKind
 	c.state.Operation = c.createReplayOperation(operation)
 	c.state.Unraid = c.refreshUnraid()

--- a/daemon/services/core/scatter.go
+++ b/daemon/services/core/scatter.go
@@ -65,7 +65,6 @@ func (c *Core) scatterPlanPrepare(setup domain.ScatterSetup) {
 
 func (c *Core) scatterPlan(plan *domain.Plan) {
 	c.scatterPlanStart(plan)
-	c.scatterPlanEnd(plan)
 }
 
 func (c *Core) scatterPlanStart(plan *domain.Plan) {
@@ -159,7 +158,14 @@ func (c *Core) scatterPlanStart(plan *domain.Plan) {
 func (c *Core) scatterPlanEnd(plan *domain.Plan) {
 	c.state.Status = common.OpNeutral
 
-	packet := &domain.Packet{Topic: common.EventScatterPlanEnded, Payload: plan}
+	planView, err := c.storePendingPlan(planFlowScatter, plan)
+	if err != nil {
+		logger.Red("unable to store scatter plan: %s", err)
+		c.publishOperationError("unable to store scatter plan: %s", err)
+		return
+	}
+
+	packet := &domain.Packet{Topic: common.EventScatterPlanEnded, Payload: planView}
 	c.ctx.Hub.Pub(packet, "socket:broadcast")
 
 	// TODO: finish implementation
@@ -172,7 +178,14 @@ func (c *Core) scatterPlanEnd(plan *domain.Plan) {
 }
 
 // SCATTER TRANSFER
-func (c *Core) scatterMove(plan domain.Plan) {
+func (c *Core) scatterMove(planID string) {
+	plan, err := c.takePendingPlan(planID, planFlowScatter)
+	if err != nil {
+		logger.Yellow("scatterMove: %s", err)
+		c.publishOperationError("unable to start scatter move: %s", err)
+		return
+	}
+
 	c.state.Status = common.OpScatterMove
 	c.state.Unraid = c.refreshUnraid()
 	c.state.Operation = c.createScatterOperation(plan)
@@ -180,7 +193,14 @@ func (c *Core) scatterMove(plan domain.Plan) {
 	go c.runOperation("Move")
 }
 
-func (c *Core) scatterCopy(plan domain.Plan) {
+func (c *Core) scatterCopy(planID string) {
+	plan, err := c.takePendingPlan(planID, planFlowScatter)
+	if err != nil {
+		logger.Yellow("scatterCopy: %s", err)
+		c.publishOperationError("unable to start scatter copy: %s", err)
+		return
+	}
+
 	c.state.Status = common.OpScatterCopy
 	c.state.Unraid = c.refreshUnraid()
 	c.state.Operation = c.createScatterOperation(plan)
@@ -208,6 +228,9 @@ func (c *Core) createScatterOperation(plan domain.Plan) *domain.Operation {
 
 	for _, disk := range c.state.Unraid.Disks {
 		vdisk := plan.VDisks[disk.Path]
+		if vdisk == nil {
+			continue
+		}
 
 		if vdisk.Bin == nil || vdisk.Src {
 			continue
@@ -239,7 +262,14 @@ func (c *Core) createScatterOperation(plan domain.Plan) *domain.Operation {
 }
 
 // SCATTER VALIDATE
-func (c *Core) scatterValidate(operation domain.Operation) {
+func (c *Core) scatterValidate(operationID string) {
+	operation, err := c.historyOperation(operationID)
+	if err != nil {
+		logger.Yellow("scatterValidate: %s", err)
+		c.publishOperationError("unable to start scatter validate: %s", err)
+		return
+	}
+
 	c.state.Status = common.OpScatterValidate
 	c.state.Unraid = c.refreshUnraid()
 	c.state.Operation = c.createScatterValidateOperation(operation)
@@ -255,7 +285,10 @@ func (c *Core) createScatterValidateOperation(original domain.Operation) *domain
 		DryRun:          false,
 	}
 
-	operation.RsyncArgs = append([]string{strings.Replace(common.RsyncArgs, "-a", "-rc", -1)}, original.RsyncArgs[1:]...)
+	operation.RsyncArgs = []string{strings.Replace(common.RsyncArgs, "-a", "-rc", -1)}
+	if len(original.RsyncArgs) > 1 {
+		operation.RsyncArgs = append(operation.RsyncArgs, original.RsyncArgs[1:]...)
+	}
 	operation.RsyncStrArgs = strings.Join(operation.RsyncArgs, " ")
 
 	operation.Commands = original.Commands

--- a/daemon/services/core/tickets.go
+++ b/daemon/services/core/tickets.go
@@ -1,0 +1,180 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/teris-io/shortid"
+
+	"unbalance/daemon/common"
+	"unbalance/daemon/domain"
+)
+
+const pendingPlanTTL = 2 * time.Hour
+
+type planFlow string
+
+const (
+	planFlowScatter planFlow = "scatter"
+	planFlowGather  planFlow = "gather"
+)
+
+type planTicket struct {
+	ID        string
+	Flow      planFlow
+	Plan      domain.Plan
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+type operationRef struct {
+	OperationID string `json:"operationID"`
+}
+
+type commandRef struct {
+	OperationID string `json:"operationID"`
+	CommandID   string `json:"commandID"`
+}
+
+type planRef struct {
+	PlanID string `json:"planID"`
+	Target string `json:"target"`
+}
+
+func newPlanID() string {
+	return shortid.MustGenerate()
+}
+
+func (c *Core) storePendingPlan(flow planFlow, plan *domain.Plan) (*domain.Plan, error) {
+	if plan == nil {
+		return nil, fmt.Errorf("missing plan")
+	}
+
+	stored, err := clonePlan(*plan)
+	if err != nil {
+		return nil, err
+	}
+
+	if stored.ID == "" {
+		stored.ID = newPlanID()
+	}
+
+	now := time.Now()
+	ticket := &planTicket{
+		ID:        stored.ID,
+		Flow:      flow,
+		Plan:      stored,
+		CreatedAt: now,
+		ExpiresAt: now.Add(pendingPlanTTL),
+	}
+
+	c.pendingPlansMu.Lock()
+	defer c.pendingPlansMu.Unlock()
+	c.pruneExpiredPendingPlansLocked(now)
+	c.pendingPlans[ticket.ID] = ticket
+
+	view, err := clonePlan(stored)
+	if err != nil {
+		return nil, err
+	}
+
+	return &view, nil
+}
+
+func (c *Core) takePendingPlan(id string, flow planFlow) (domain.Plan, error) {
+	if id == "" {
+		return domain.Plan{}, fmt.Errorf("missing planID")
+	}
+
+	now := time.Now()
+	c.pendingPlansMu.Lock()
+	defer c.pendingPlansMu.Unlock()
+	c.pruneExpiredPendingPlansLocked(now)
+
+	ticket, ok := c.pendingPlans[id]
+	if !ok {
+		return domain.Plan{}, fmt.Errorf("pending plan not found or expired: %s", id)
+	}
+	if ticket.Flow != flow {
+		return domain.Plan{}, fmt.Errorf("pending plan %s is for %s, not %s", id, ticket.Flow, flow)
+	}
+
+	delete(c.pendingPlans, id)
+	return clonePlan(ticket.Plan)
+}
+
+func (c *Core) pruneExpiredPendingPlansLocked(now time.Time) {
+	for id, ticket := range c.pendingPlans {
+		if !ticket.ExpiresAt.After(now) {
+			delete(c.pendingPlans, id)
+		}
+	}
+}
+
+func clonePlan(plan domain.Plan) (domain.Plan, error) {
+	data, err := json.Marshal(plan)
+	if err != nil {
+		return domain.Plan{}, err
+	}
+
+	var cloned domain.Plan
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return domain.Plan{}, err
+	}
+
+	return cloned, nil
+}
+
+func cloneOperation(operation domain.Operation) (domain.Operation, error) {
+	data, err := json.Marshal(operation)
+	if err != nil {
+		return domain.Operation{}, err
+	}
+
+	var cloned domain.Operation
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return domain.Operation{}, err
+	}
+
+	return cloned, nil
+}
+
+func (c *Core) historyOperation(id string) (domain.Operation, error) {
+	if id == "" {
+		return domain.Operation{}, fmt.Errorf("missing operationID")
+	}
+	if c.state.History == nil || c.state.History.Items == nil {
+		return domain.Operation{}, fmt.Errorf("history is unavailable")
+	}
+
+	operation, ok := c.state.History.Items[id]
+	if !ok || operation == nil {
+		return domain.Operation{}, fmt.Errorf("operation not found: %s", id)
+	}
+
+	return cloneOperation(*operation)
+}
+
+func findCommand(operation *domain.Operation, id string) (*domain.Command, error) {
+	if operation == nil {
+		return nil, fmt.Errorf("missing operation")
+	}
+	if id == "" {
+		return nil, fmt.Errorf("missing commandID")
+	}
+
+	for _, command := range operation.Commands {
+		if command != nil && command.ID == id {
+			return command, nil
+		}
+	}
+
+	return nil, fmt.Errorf("command not found: %s", id)
+}
+
+func (c *Core) publishOperationError(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	packet := &domain.Packet{Topic: common.EventOperationError, Payload: msg}
+	c.ctx.Hub.Pub(packet, "socket:broadcast")
+}

--- a/daemon/services/core/tickets_test.go
+++ b/daemon/services/core/tickets_test.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"unbalance/daemon/domain"
+)
+
+func testCoreWithTickets() *Core {
+	return &Core{pendingPlans: make(map[string]*planTicket)}
+}
+
+func TestPendingPlanTicketStoresCloneAndConsumesByID(t *testing.T) {
+	c := testCoreWithTickets()
+	plan := &domain.Plan{
+		BytesToTransfer: 10,
+		VDisks: map[string]*domain.VDisk{
+			"/mnt/disk1": {Path: "/mnt/disk1"},
+		},
+	}
+
+	view, err := c.storePendingPlan(planFlowScatter, plan)
+	if err != nil {
+		t.Fatalf("storePendingPlan: %s", err)
+	}
+	if view.ID == "" {
+		t.Fatalf("expected generated plan id")
+	}
+
+	// Mutating the original or returned view must not affect server-owned plan data.
+	plan.BytesToTransfer = 99
+	view.BytesToTransfer = 77
+
+	stored, err := c.takePendingPlan(view.ID, planFlowScatter)
+	if err != nil {
+		t.Fatalf("takePendingPlan: %s", err)
+	}
+	if stored.BytesToTransfer != 10 {
+		t.Fatalf("stored bytes = %d, want 10", stored.BytesToTransfer)
+	}
+
+	if _, err := c.takePendingPlan(view.ID, planFlowScatter); err == nil {
+		t.Fatalf("expected consumed plan ticket to be unavailable")
+	}
+}
+
+func TestPendingPlanTicketRejectsWrongFlowWithoutConsuming(t *testing.T) {
+	c := testCoreWithTickets()
+	view, err := c.storePendingPlan(planFlowScatter, &domain.Plan{})
+	if err != nil {
+		t.Fatalf("storePendingPlan: %s", err)
+	}
+
+	if _, err := c.takePendingPlan(view.ID, planFlowGather); err == nil {
+		t.Fatalf("expected wrong flow to be rejected")
+	}
+
+	if _, err := c.takePendingPlan(view.ID, planFlowScatter); err != nil {
+		t.Fatalf("expected ticket to remain after wrong-flow rejection: %s", err)
+	}
+}
+
+func TestPendingPlanTicketPrunesExpiredPlans(t *testing.T) {
+	c := testCoreWithTickets()
+	c.pendingPlans["expired"] = &planTicket{ID: "expired", Flow: planFlowScatter, ExpiresAt: time.Now().Add(-time.Minute)}
+
+	if _, err := c.takePendingPlan("expired", planFlowScatter); err == nil {
+		t.Fatalf("expected expired ticket to be rejected")
+	}
+	if len(c.pendingPlans) != 0 {
+		t.Fatalf("expected expired ticket to be pruned")
+	}
+}
+
+func TestHistoryOperationReturnsClone(t *testing.T) {
+	c := &Core{state: &domain.State{History: &domain.History{Items: map[string]*domain.Operation{
+		"op-1": {ID: "op-1", Commands: []*domain.Command{{ID: "cmd-1", Entry: "original"}}},
+	}}}}
+
+	operation, err := c.historyOperation("op-1")
+	if err != nil {
+		t.Fatalf("historyOperation: %s", err)
+	}
+	operation.Commands[0].Entry = "mutated"
+
+	if got := c.state.History.Items["op-1"].Commands[0].Entry; got != "original" {
+		t.Fatalf("history operation was mutated through clone, got %q", got)
+	}
+}

--- a/ui/src/state/unraid.tsx
+++ b/ui/src/state/unraid.tsx
@@ -362,7 +362,7 @@ export const useUnraidStore = create<UnraidStore>()(
           socket.send(
             JSON.stringify({
               topic: command,
-              payload: plan,
+              payload: { planID: plan.id },
             }),
           );
 
@@ -391,7 +391,7 @@ export const useUnraidStore = create<UnraidStore>()(
           socket.send(
             JSON.stringify({
               topic: Topic.CommandScatterValidate,
-              payload: operation,
+              payload: { operationID: operation.id },
             }),
           );
 
@@ -480,7 +480,7 @@ export const useUnraidStore = create<UnraidStore>()(
           socket.send(
             JSON.stringify({
               topic: Topic.CommandGatherMove,
-              payload: { ...plan, target },
+              payload: { planID: plan.id, target },
             }),
           );
 
@@ -512,7 +512,7 @@ export const useUnraidStore = create<UnraidStore>()(
           socket.send(
             JSON.stringify({
               topic: Topic.CommandRemoveSource,
-              payload: { operation, command },
+              payload: { operationID: operation.id, commandID: command.id },
             }),
           );
 
@@ -540,7 +540,7 @@ export const useUnraidStore = create<UnraidStore>()(
           socket.send(
             JSON.stringify({
               topic: Topic.CommandReplay,
-              payload: operation,
+              payload: { operationID: operation.id },
             }),
           );
 

--- a/ui/src/types.tsx
+++ b/ui/src/types.tsx
@@ -131,6 +131,7 @@ export interface VDisk {
 }
 
 export interface Plan {
+  id: string;
   started: Date;
   ended: Date;
   chosenFolders: string[];
@@ -212,7 +213,7 @@ export enum Topic {
 
 export interface Packet {
   topic: Topic;
-  payload: string;
+  payload: unknown;
 }
 
 export enum ConfirmationKind {


### PR DESCRIPTION
## Summary
- add memory-only pending plan tickets and return `plan.id` from plan completion events
- change execution websocket commands to send IDs instead of full executable objects:
  - `scatter:move` / `scatter:copy` -> `{ planID }`
  - `gather:move` -> `{ planID, target }`
  - `scatter:validate` / `replay` -> `{ operationID }`
  - `remove:source` -> `{ operationID, commandID }`
- make replay/validate/remove-source look up server-owned history entries before execution
- clone stored plans/history operations before use so UI/display payload mutation cannot affect server authority
- fix duplicate `plan:ended` emission so each plan creates one pending ticket

## Validation
- `git diff --check`
- `GOOS=linux GOARCH=amd64 go test -c ./daemon/services/core -o /tmp/unbalance-core-linux.test`
- copied and ran `/tmp/unbalance-core-linux.test -test.v` on `hal` — all 10 core tests passed
- `cd ui && npm run build`
- `GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=2026.05.02-2163028" -o /tmp/unbalanced-id-ws .`
- contained `hal` integration test under `/mnt/disk1/testing` and `/mnt/disk2/testing`:
  - started test binary on port `17091`
  - sent `scatter:plan:start`
  - verified exactly one `scatter:plan:ended` with a server-generated `planID`
  - sent `scatter:move` with only `{ planID }`
  - verified rsync completed, source payload was removed, destination payload remained, sentinels remained
  - guarded-cleaned only the unique `unbalance-it-idws-*` fixture

## Reboot semantics
Pending unexecuted plans are memory-only. A server restart invalidates them and the user must re-plan, which is intentional because pending plan execution authority should not survive stale disk state.
