### PR TITLE
Reject unsafe rsync arguments

### DIFF
--- a/daemon/services/core/core.go
+++ b/daemon/services/core/core.go
@@ -285,12 +285,19 @@ func (c *Core) SetReservedSpace(amount uint64, unit string) *domain.Config {
 	return &c.ctx.Config
 }
 
-func (c *Core) SetRsyncArgs(value []string) *domain.Config {
+func (c *Core) SetRsyncArgs(value []string) (*domain.Config, error) {
+	value = cleanRsyncArgs(value)
+	if err := validateRsyncArgs(value); err != nil {
+		logger.Yellow("setRsyncArgs: rejected args %v: %s", value, err)
+		return &c.ctx.Config, err
+	}
+
 	c.ctx.Config.RsyncArgs = value
 	if err := c.saveSettings(); err != nil {
 		logger.Yellow("setRsyncArgs: unable to save settings: %s", err)
+		return &c.ctx.Config, err
 	}
-	return &c.ctx.Config
+	return &c.ctx.Config, nil
 }
 
 func (c *Core) SetVerbosity(value int) *domain.Config {

--- a/daemon/services/core/operation.go
+++ b/daemon/services/core/operation.go
@@ -19,6 +19,14 @@ func (c *Core) runOperation(opName string) {
 	logger.Blue("running %s operation ...", opName)
 
 	operation := c.state.Operation
+	if err := validateRsyncArgs(operation.RsyncArgs); err != nil {
+		logger.Yellow("operation:rsync-args:blocked:%s", err)
+		c.publishOperationError("unable to start %s operation: %s", opName, err)
+		c.state.Status = common.OpNeutral
+		c.state.Operation = nil
+		return
+	}
+
 	operation.Started = time.Now()
 
 	if c.ctx.NotifyTransfer == 2 {

--- a/daemon/services/core/rsync_policy.go
+++ b/daemon/services/core/rsync_policy.go
@@ -1,0 +1,47 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+)
+
+var blockedRsyncArgReasons = map[string]string{
+	"--remove-source-files": "unbalanced manages source deletion after validated transfers",
+	"--rsync-path":          "remote rsync command execution is outside unbalanced's local transfer model",
+	"--rsh":                 "remote shell execution is outside unbalanced's local transfer model",
+	"-e":                    "remote shell execution is outside unbalanced's local transfer model",
+}
+
+func validateRsyncArgs(args []string) error {
+	for _, arg := range args {
+		arg = strings.TrimSpace(arg)
+		if arg == "" {
+			continue
+		}
+
+		if arg == "--delete" || strings.HasPrefix(arg, "--delete-") {
+			return fmt.Errorf("rsync option %q is not allowed because unbalanced does not perform destination mirroring/deletion", arg)
+		}
+
+		for blocked, reason := range blockedRsyncArgReasons {
+			if arg == blocked || strings.HasPrefix(arg, blocked+"=") || (blocked == "-e" && strings.HasPrefix(arg, "-e")) {
+				return fmt.Errorf("rsync option %q is not allowed because %s", arg, reason)
+			}
+		}
+	}
+
+	return nil
+}
+
+func cleanRsyncArgs(args []string) []string {
+	cleaned := make([]string, 0, len(args))
+	for _, arg := range args {
+		arg = strings.TrimSpace(arg)
+		if arg == "" {
+			continue
+		}
+		cleaned = append(cleaned, arg)
+	}
+
+	return cleaned
+}

--- a/daemon/services/core/rsync_policy_core_test.go
+++ b/daemon/services/core/rsync_policy_core_test.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"testing"
+
+	"unbalance/daemon/domain"
+)
+
+func TestSetRsyncArgsRejectsBlockedArgAndKeepsConfig(t *testing.T) {
+	c := &Core{ctx: &domain.Context{Config: domain.Config{RsyncArgs: []string{"-X"}}}}
+
+	_, err := c.SetRsyncArgs([]string{"--remove-source-files"})
+	if err == nil {
+		t.Fatalf("expected blocked arg to be rejected")
+	}
+
+	if len(c.ctx.Config.RsyncArgs) != 1 || c.ctx.Config.RsyncArgs[0] != "-X" {
+		t.Fatalf("config changed after rejected arg: %v", c.ctx.Config.RsyncArgs)
+	}
+}

--- a/daemon/services/core/rsync_policy_test.go
+++ b/daemon/services/core/rsync_policy_test.go
@@ -1,0 +1,60 @@
+package core
+
+import "testing"
+
+func TestValidateRsyncArgsAllowsCommonLocalOptions(t *testing.T) {
+	args := []string{
+		"-avPR",
+		"-X",
+		"-A",
+		"-H",
+		"--numeric-ids",
+		"--inplace",
+		"--info=progress2",
+		"--partial",
+		"--bwlimit=50000",
+		"--dry-run",
+		"",
+		"  ",
+	}
+
+	if err := validateRsyncArgs(args); err != nil {
+		t.Fatalf("expected args to be allowed: %s", err)
+	}
+}
+
+func TestValidateRsyncArgsBlocksDangerousOptions(t *testing.T) {
+	tests := [][]string{
+		{"--delete"},
+		{"--delete-before"},
+		{"--delete-after"},
+		{"--delete-excluded"},
+		{"--remove-source-files"},
+		{"--rsync-path=/tmp/rsync"},
+		{"--rsync-path", "/tmp/rsync"},
+		{"-e", "ssh"},
+		{"-essh"},
+		{"--rsh=ssh"},
+		{"--rsh", "ssh"},
+	}
+
+	for _, args := range tests {
+		if err := validateRsyncArgs(args); err == nil {
+			t.Fatalf("expected %v to be blocked", args)
+		}
+	}
+}
+
+func TestCleanRsyncArgsTrimsAndDropsEmptyArgs(t *testing.T) {
+	got := cleanRsyncArgs([]string{" -X ", "", "\t", "--partial"})
+	want := []string{"-X", "--partial"}
+
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/daemon/services/server/server.go
+++ b/daemon/services/server/server.go
@@ -272,7 +272,12 @@ func (s *Server) setRsyncArgs(c echo.Context) error {
 		return err
 	}
 
-	return c.JSON(200, s.core.SetRsyncArgs(value))
+	config, err := s.core.SetRsyncArgs(value)
+	if err != nil {
+		return echo.NewHTTPError(400, err.Error())
+	}
+
+	return c.JSON(200, config)
 }
 
 func (s *Server) setVerbosity(c echo.Context) error {

--- a/ui/src/api/index.tsx
+++ b/ui/src/api/index.tsx
@@ -207,11 +207,11 @@ export class Api {
       headers: { 'Content-Type': 'application/json', ...Api.authHeaders() },
       body: JSON.stringify(flags),
     };
-    try {
-      const url = `${Api.host}/config/rsyncArgs`;
-      await fetch(url, options);
-    } catch (e) {
-      console.log('rsyncArgs() error: ', e);
+    const url = `${Api.host}/config/rsyncArgs`;
+    const response = await fetch(url, options);
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || response.statusText);
     }
   }
 

--- a/ui/src/flows/settings/flags.tsx
+++ b/ui/src/flows/settings/flags.tsx
@@ -8,20 +8,31 @@ import { useConfigActions, useConfigRsyncArgs } from '~/state/config';
 export const Flags: React.FunctionComponent = () => {
   const flags = useConfigRsyncArgs();
   const [flagsValue, setFlagsValue] = React.useState(flags.join(' '));
+  const [error, setError] = React.useState('');
   const { setRsyncArgs, resetRsyncArgs } = useConfigActions();
 
   const onFlagsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFlagsValue(e.target.value);
   };
 
-  const onApply = () => {
-    const flags = flagsValue.split(' ');
-    setRsyncArgs(flags);
+  const onApply = async () => {
+    const flags = flagsValue.split(/\s+/).filter(Boolean);
+    try {
+      await setRsyncArgs(flags);
+      setError('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unable to save rsync flags');
+    }
   };
 
-  const onReset = () => {
+  const onReset = async () => {
     setFlagsValue('-X');
-    resetRsyncArgs();
+    try {
+      await resetRsyncArgs();
+      setError('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unable to reset rsync flags');
+    }
   };
 
   return (
@@ -41,8 +52,8 @@ export const Flags: React.FunctionComponent = () => {
         automatically added, if needed. <br />
         <span className="text-red-900 dark:text-red-700 font-bold">
           NOTE: These settings are meant to be changed by advanced users only.
-          No validation is currently performed on the flags you manually enter
-          here, so you need to know what you're doing before changing them.
+          Destructive or remote-execution rsync options are blocked because
+          unbalanced manages source deletion and local transfer behavior itself.
         </span>
       </h1>
       <div className="pb-4" />
@@ -65,6 +76,9 @@ export const Flags: React.FunctionComponent = () => {
           Reset to Defaults
         </Button>
       </div>
+      {error !== '' && (
+        <p className="pt-3 text-sm text-red-900 dark:text-red-700">{error}</p>
+      )}
     </div>
   );
 };

--- a/ui/src/state/config.tsx
+++ b/ui/src/state/config.tsx
@@ -80,16 +80,16 @@ export const useConfigStore = create<ConfigStore>()(
         await Api.setReservedSpace(amount, unit);
       },
       setRsyncArgs: async (flags: string[]) => {
+        await Api.setRsyncArgs(flags);
         set((state) => {
           state.rsyncArgs = flags;
         });
-        await Api.setRsyncArgs(flags);
       },
       resetRsyncArgs: async () => {
+        await Api.setRsyncArgs(['-X']);
         set((state) => {
           state.rsyncArgs = ['-X'];
         });
-        await Api.setRsyncArgs(['-X']);
       },
       setVerbosity: async (value: number) => {
         set((state) => {


### PR DESCRIPTION
## Summary
- add rsync argument policy validation for destructive/remote-execution options
- reject blocked args when saving settings and again before operation execution
- surface settings-save failures in the UI instead of silently accepting them
- log rejected rsync args for auditability

Blocked examples:
- `--delete`, `--delete-*`
- `--remove-source-files`
- `--rsync-path`
- `-e`, `--rsh`

## Validation
- `git diff --check`
- `GOOS=linux GOARCH=amd64 go test -c ./daemon/services/core -o /tmp/unbalance-core-rsync-policy.test`
- copied and ran `/tmp/unbalance-core-rsync-policy.test -test.v` on `hal` — all 14 core tests passed
- `cd ui && npm run build`
- `GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=2026.05.02-b6b6b4f" -o /tmp/unbalanced-rsync-policy .`
- native `hal` smoke on port 7090:
  - allowed `-X` move completed successfully
  - attempted `-X --remove-source-files` was rejected in UI/API
  - rejection logged to `/var/log/unbalanced.log`:
    `setRsyncArgs: rejected args [-X --remove-source-files]: rsync option "--remove-source-files" is not allowed because unbalanced manages source deletion after validated transfers`
