### PR TITLE
Adjust replay logic

### DIFF
--- a/daemon/services/core/operation.go
+++ b/daemon/services/core/operation.go
@@ -446,15 +446,20 @@ func (c *Core) createReplayOperation(original domain.Operation) *domain.Operatio
 		DryRun:          false,
 	}
 
-	operation.RsyncArgs = original.RsyncArgs
+	operation.RsyncArgs = append([]string(nil), original.RsyncArgs...)
 	operation.RsyncStrArgs = strings.Join(operation.RsyncArgs, " ")
 
-	operation.Commands = original.Commands
+	operation.Commands = make([]*domain.Command, 0, len(original.Commands))
+	for _, originalCommand := range original.Commands {
+		if originalCommand == nil {
+			continue
+		}
 
-	for _, command := range operation.Commands {
+		command := *originalCommand
 		command.ID = shortid.MustGenerate()
 		command.Transferred = 0
 		command.Status = common.CmdPending
+		operation.Commands = append(operation.Commands, &command)
 	}
 
 	return operation

--- a/daemon/services/core/replay_test.go
+++ b/daemon/services/core/replay_test.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"testing"
+
+	"unbalance/daemon/common"
+	"unbalance/daemon/domain"
+)
+
+func TestCreateReplayOperationDoesNotMutateOriginal(t *testing.T) {
+	c := &Core{}
+	originalCommand := &domain.Command{
+		ID:          "original-command",
+		Src:         "/mnt/disk1",
+		Dst:         "/mnt/disk2/",
+		Entry:       "share/file.bin",
+		Size:        123,
+		Transferred: 123,
+		Status:      common.CmdCompleted,
+	}
+	original := domain.Operation{
+		ID:              "original-operation",
+		OpKind:          common.OpScatterMove,
+		BytesToTransfer: 123,
+		RsyncArgs:       []string{"-avPR", "-X"},
+		Commands:        []*domain.Command{originalCommand},
+	}
+
+	replay := c.createReplayOperation(original)
+	if replay.ID == original.ID {
+		t.Fatalf("replay operation reused original id")
+	}
+	if len(replay.Commands) != 1 {
+		t.Fatalf("replay command count = %d, want 1", len(replay.Commands))
+	}
+
+	replayCommand := replay.Commands[0]
+	if replayCommand == originalCommand {
+		t.Fatalf("replay command reused original command pointer")
+	}
+	if replayCommand.ID == originalCommand.ID {
+		t.Fatalf("replay command reused original command id")
+	}
+	if replayCommand.Transferred != 0 {
+		t.Fatalf("replay transferred = %d, want 0", replayCommand.Transferred)
+	}
+	if replayCommand.Status != common.CmdPending {
+		t.Fatalf("replay status = %d, want pending", replayCommand.Status)
+	}
+
+	if originalCommand.ID != "original-command" {
+		t.Fatalf("original command id mutated to %q", originalCommand.ID)
+	}
+	if originalCommand.Transferred != 123 {
+		t.Fatalf("original transferred mutated to %d", originalCommand.Transferred)
+	}
+	if originalCommand.Status != common.CmdCompleted {
+		t.Fatalf("original status mutated to %d", originalCommand.Status)
+	}
+
+	replay.RsyncArgs[1] = "--changed"
+	if original.RsyncArgs[1] != "-X" {
+		t.Fatalf("original rsync args mutated to %v", original.RsyncArgs)
+	}
+}


### PR DESCRIPTION
## Summary
- clone replay command data instead of reusing command pointers from history
- reset replay command IDs/status/progress on the cloned command list
- copy replay rsync args before execution setup
- add regression coverage to ensure replay setup does not mutate the original history operation

## Validation
- `git diff --check`
- `GOOS=linux GOARCH=amd64 go test -c ./daemon/services/core -o /tmp/unbalance-core-replay.test`
- copied and ran `/tmp/unbalance-core-replay.test -test.v` on `hal` — all 15 core tests passed
- `cd ui && npm run build`
- `GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=2026.05.02-42c3090" -o /tmp/unbalanced-replay .`
