### PR TITLE
Drop /bin/sh wrapper from planner find calls

### DIFF
--- a/daemon/lib/shell.go
+++ b/daemon/lib/shell.go
@@ -83,9 +83,12 @@ func scanLinesEx(data []byte, atEOF bool) (advance int, token []byte, err error)
 	return 0, nil, nil
 }
 
-func Shell2(command string, callback Callback) error {
-	args := append([]string{"-c"}, command)
-	cmd := exec.Command("/bin/sh", args...)
+// Stream runs name with args directly (no shell), invoking callback for each
+// stdout line. It is the no-shell replacement for the legacy Shell2 helper:
+// arguments are passed as argv tokens, so caller-supplied paths cannot be
+// interpreted as shell metacharacters.
+func Stream(name string, args []string, callback Callback) error {
+	cmd := exec.Command(name, args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -102,7 +105,6 @@ func Shell2(command string, callback Callback) error {
 		callback(scanner.Text())
 	}
 
-	// Wait for the result of the command; also closes our end of the pipe
 	return cmd.Wait()
 }
 

--- a/daemon/services/core/helper.go
+++ b/daemon/services/core/helper.go
@@ -45,9 +45,9 @@ func getIssues(re *regexp.Regexp, disk *domain.Disk, path string) (int64, int64,
 	}
 
 	scanFolder := folder + "/."
-	cmd := fmt.Sprintf(`find "%s" -exec stat --format "%%A|%%U:%%G|%%F|%%n" {} \;`, scanFolder)
+	findArgs := []string{scanFolder, "-exec", "stat", "--format=%A|%U:%G|%F|%n", "{}", ";"}
 
-	err := lib.Shell2(cmd, func(line string) {
+	err := lib.Stream("find", findArgs, func(line string) {
 		result := re.FindStringSubmatch(line)
 		if result == nil {
 			return
@@ -113,9 +113,9 @@ func getItems(blockSize uint64, re *regexp.Regexp, src, folder string) ([]*domai
 
 	items := make([]*domain.Item, 0)
 
-	cmd := fmt.Sprintf(`find "%s" ! -name . -prune -exec du -bs {} +`, srcFolder+"/.")
+	findArgs := []string{srcFolder + "/.", "!", "-name", ".", "-prune", "-exec", "du", "-bs", "{}", "+"}
 
-	err = lib.Shell2(cmd, func(line string) {
+	err = lib.Stream("find", findArgs, func(line string) {
 		result := re.FindStringSubmatch(line)
 
 		size, _ := strconv.ParseInt(result[1], 10, 64)

--- a/daemon/services/core/helper_security_probe_test.go
+++ b/daemon/services/core/helper_security_probe_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"unbalance/daemon/domain"
+)
+
+// TestHelperSecurityProbe is a manual probe harness for the no-shell migration
+// of getIssues/getItems. It is skipped unless UNBALANCE_PROBE_DISK and
+// UNBALANCE_PROBE_PATH are set, so it never runs in normal test runs.
+//
+//	UNBALANCE_PROBE_DISK=/mnt/disk1/testing/security-helper-fixtures \
+//	UNBALANCE_PROBE_PATH=root \
+//	./unbalance-core.test -test.v -test.run TestHelperSecurityProbe
+//
+// The probe calls the same unexported helpers the planner uses, so we exercise
+// the real find/stat and find/du paths against the fixture without standing up
+// the full daemon.
+func TestHelperSecurityProbe(t *testing.T) {
+	diskPath := os.Getenv("UNBALANCE_PROBE_DISK")
+	subPath := os.Getenv("UNBALANCE_PROBE_PATH")
+	if diskPath == "" || subPath == "" {
+		t.Skip("set UNBALANCE_PROBE_DISK and UNBALANCE_PROBE_PATH to run the security probe")
+	}
+
+	full := filepath.Join(diskPath, subPath)
+	if _, err := os.Stat(full); err != nil {
+		t.Fatalf("fixture %s not accessible: %v", full, err)
+	}
+
+	disk := &domain.Disk{Path: diskPath}
+
+	t.Logf("probe disk=%s sub=%s full=%s", diskPath, subPath, full)
+
+	ownerIssue, groupIssue, folderIssue, fileIssue, err := getIssues(reStat, disk, subPath)
+	if err != nil {
+		t.Fatalf("getIssues error: %v", err)
+	}
+	t.Logf("issues: owner=%d group=%d folder=%d file=%d", ownerIssue, groupIssue, folderIssue, fileIssue)
+
+	items, total, err := getItems(0, reItems, diskPath, subPath)
+	if err != nil {
+		t.Fatalf("getItems error: %v", err)
+	}
+	t.Logf("items: count=%d total_bytes=%d", len(items), total)
+	for _, it := range items {
+		t.Logf("  item size=%d name=%s path=%s", it.Size, it.Name, it.Path)
+	}
+}


### PR DESCRIPTION
## Summary

`getIssues` and `getItems` in `daemon/services/core/helper.go` previously built shell command strings via `fmt.Sprintf` and ran them through `/bin/sh -c`. A folder name containing shell metacharacters (`$(...)`, backticks, `;`, `&&`, `|`, etc.) would be interpreted by the shell before `find` ever saw it.

This PR moves both call sites to direct `exec.Command` via a new `lib.Stream(name, args, callback)` helper. `find`, `stat`, and `du -bs` are still invoked — same flags, same output shape — but argv tokens go straight to `find` with no shell layer in between.

## What didn't change

- Still `/usr/bin/find` driving `stat --format=%A|%U:%G|%F|%n` and `du -bs`.
- Same regexes (`reStat`, `reItems`) parse the output unchanged.
- `du -bs` semantics preserved: hard-link dedup, apparent-size for sparse files, `-exec ... +` batching all behave exactly as before.
- `lib.Shell` (workdir variant) is kept — its callers in `array.go` use static strings that rely on shell glob expansion (`df --block-size=1 /mnt/*`).

## What did change

- New `lib.Stream(name string, args []string, callback Callback) error` in `daemon/lib/shell.go`. Same streaming behavior as the old `Shell2`, but `exec.Command(name, args...)` instead of `exec.Command("/bin/sh", "-c", ...)`.
- `lib.Shell2` had no other callers and is removed.
- Gated probe test `daemon/services/core/helper_security_probe_test.go`. Skips by default; runs when `UNBALANCE_PROBE_DISK` and `UNBALANCE_PROBE_PATH` are set, so the parity check can be re-run on a real array on demand.

## Validation

Cross-compiled to linux/amd64 and validated on hal against a 110-file fixture containing:
- Shell-metacharacter filenames: `foo;rm-rf-test.mkv`, `qux$(whoami).mkv`, `back\`tick\`.mkv`, `&&pipe||.mkv`, `with;semi.mkv`, `with space.mkv`, `quote"d".mkv`.
- A hard-link pair sharing one inode.
- A 1 GiB sparse file.

`getItems` per-child sizes matched the raw `find ... -exec du -bs {} +` baseline byte-for-byte (total 1,077,690,403 bytes), including hard-link dedup (16,384 for two hardlinked 16 KiB files) and sparse-file apparent size (1,073,741,824). `getIssues` counts (owner=121, group=121, folder=11, file=110) match the expected values for the all-`root:root`/`644` fixture.