### PR TITLE
Tighten websocket auth lifecycle

### DIFF
--- a/daemon/services/server/auth.go
+++ b/daemon/services/server/auth.go
@@ -364,14 +364,20 @@ func (s *Server) createSession(c echo.Context, username string) (session, error)
 }
 
 func (s *Server) clearSession(c echo.Context) {
+	var clearedID string
 	cookie, err := c.Cookie(sessionCookieName)
 	if err == nil {
+		clearedID = cookie.Value
 		s.sessionMu.Lock()
 		delete(s.sessions, cookie.Value)
 		if saveErr := s.saveSessionsLocked(); saveErr != nil {
 			logger.Red("unable to persist cleared auth session: %s", saveErr)
 		}
 		s.sessionMu.Unlock()
+	}
+
+	if clearedID != "" {
+		s.closeWebsocketIfSession(clearedID)
 	}
 
 	c.SetCookie(&http.Cookie{
@@ -392,6 +398,58 @@ func (s *Server) clearAllSessions() {
 		logger.Red("unable to clear persisted auth sessions: %s", err)
 	}
 	s.sessionMu.Unlock()
+
+	s.closeAnyWebsocket()
+}
+
+// sessionStillValid reports whether the session id is currently in the store
+// and not yet expired. Used by the websocket read loop to revalidate after
+// upgrade so a logged-out or expired session cannot keep publishing commands.
+func (s *Server) sessionStillValid(sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+
+	s.sessionMu.Lock()
+	defer s.sessionMu.Unlock()
+
+	info, ok := s.sessions[sessionID]
+	if !ok {
+		return false
+	}
+
+	return time.Now().Before(info.Expires)
+}
+
+// closeWebsocketIfSession closes the active websocket if it was upgraded by
+// the given session. The read loop's ReadJSON returns an error on close and
+// the goroutine exits via the existing error path.
+func (s *Server) closeWebsocketIfSession(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+
+	s.wsMu.Lock()
+	defer s.wsMu.Unlock()
+
+	if s.ws != nil && s.wsSession == sessionID {
+		_ = s.ws.Close()
+		s.ws = nil
+		s.wsSession = ""
+	}
+}
+
+// closeAnyWebsocket forcibly closes the active websocket regardless of which
+// session opened it; called when every session is being invalidated.
+func (s *Server) closeAnyWebsocket() {
+	s.wsMu.Lock()
+	defer s.wsMu.Unlock()
+
+	if s.ws != nil {
+		_ = s.ws.Close()
+		s.ws = nil
+		s.wsSession = ""
+	}
 }
 
 func (s *Server) pruneSessions() {
@@ -401,20 +459,24 @@ func (s *Server) pruneSessions() {
 	for range ticker.C {
 		now := time.Now()
 
+		var pruned []string
 		s.sessionMu.Lock()
-		dirty := false
 		for key, info := range s.sessions {
 			if now.After(info.Expires) {
 				delete(s.sessions, key)
-				dirty = true
+				pruned = append(pruned, key)
 			}
 		}
-		if dirty {
+		if len(pruned) > 0 {
 			if err := s.saveSessionsLocked(); err != nil {
 				logger.Red("unable to prune persisted auth sessions: %s", err)
 			}
 		}
 		s.sessionMu.Unlock()
+
+		for _, key := range pruned {
+			s.closeWebsocketIfSession(key)
+		}
 
 		s.limiterMu.Lock()
 		for key, attempt := range s.limiter {

--- a/daemon/services/server/auth_test.go
+++ b/daemon/services/server/auth_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestSessionStillValid(t *testing.T) {
+	s := &Server{
+		sessions: newSessionStore(),
+	}
+
+	now := time.Now()
+	s.sessions["good"] = session{Username: "u", CSRF: "c", Expires: now.Add(1 * time.Hour)}
+	s.sessions["expired"] = session{Username: "u", CSRF: "c", Expires: now.Add(-1 * time.Minute)}
+
+	cases := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"valid", "good", true},
+		{"expired", "expired", false},
+		{"missing", "nope", false},
+		{"empty", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := s.sessionStillValid(tc.id)
+			if got != tc.want {
+				t.Fatalf("sessionStillValid(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUpgraderCheckOrigin(t *testing.T) {
+	cases := []struct {
+		name   string
+		origin string
+		host   string
+		want   bool
+	}{
+		{"empty origin rejected", "", "host.example", false},
+		{"matching host accepted", "https://host.example", "host.example", true},
+		{"matching host with port", "http://host.example:8080", "host.example:8080", true},
+		{"scheme difference ignored (proxy)", "http://host.example", "host.example", true},
+		{"different host rejected", "https://attacker.example", "host.example", false},
+		{"malformed origin rejected", "://broken", "host.example", false},
+		{"opaque origin rejected", "null", "host.example", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &http.Request{
+				Host:   tc.host,
+				Header: http.Header{},
+			}
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			got := upgrader.CheckOrigin(req)
+			if got != tc.want {
+				t.Fatalf("CheckOrigin(origin=%q,host=%q) = %v, want %v", tc.origin, tc.host, got, tc.want)
+			}
+		})
+	}
+}

--- a/daemon/services/server/server.go
+++ b/daemon/services/server/server.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/gorilla/websocket"
@@ -25,6 +26,22 @@ import (
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
+	// Reject browsers that don't send Origin and any cross-host upgrade
+	// attempt regardless of the auth state. We only compare hosts (not
+	// schemes) so a TLS-terminating reverse proxy that strips the scheme
+	// still works; the per-request validateWebsocketRequest check in auth.go
+	// is what enforces session+CSRF when auth is enabled.
+	CheckOrigin: func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return false
+		}
+		u, err := url.Parse(origin)
+		if err != nil || u.Host == "" {
+			return false
+		}
+		return strings.EqualFold(u.Host, r.Host)
+	},
 }
 
 type Server struct {
@@ -32,6 +49,8 @@ type Server struct {
 	core          *core.Core
 	engine        *echo.Echo
 	ws            *websocket.Conn
+	wsSession     string
+	wsMu          sync.Mutex
 	broadcastChan chan any
 	sessions      map[string]session
 	sessionMu     sync.Mutex
@@ -130,6 +149,15 @@ func (s *Server) wsHandler(c echo.Context) error {
 		return err
 	}
 
+	// Capture the session id from the cookie so the read loop and the
+	// session-revocation hooks can identify which connection belongs to
+	// which session. Empty when auth is disabled — sessionStillValid skips
+	// the per-message check in that case.
+	var sessionID string
+	if cookie, err := c.Cookie(sessionCookieName); err == nil {
+		sessionID = cookie.Value
+	}
+
 	conn, err := upgrader.Upgrade(c.Response(), c.Request(), nil)
 	if err != nil {
 		logger.Red("unable to upgrade websocket: %s", err)
@@ -137,18 +165,29 @@ func (s *Server) wsHandler(c echo.Context) error {
 	}
 	defer conn.Close()
 
+	s.wsMu.Lock()
 	s.ws = conn
+	s.wsSession = sessionID
+	s.wsMu.Unlock()
 
-	return s.wsRead()
+	return s.wsRead(conn, sessionID)
 }
 
-func (s *Server) wsRead() (err error) {
+func (s *Server) wsRead(conn *websocket.Conn, sessionID string) (err error) {
 	for {
 		var packet domain.Packet
-		err = s.ws.ReadJSON(&packet)
+		err = conn.ReadJSON(&packet)
 		if err != nil {
 			logger.Red("unable to read websocket message: %s", err)
 			return err
+		}
+
+		// Re-check the session on every inbound packet so an expired,
+		// logged-out, or revoked session can't keep driving destructive
+		// operations through an already-upgraded connection.
+		if s.authRequired() && !s.sessionStillValid(sessionID) {
+			logger.Yellow("websocket session no longer valid; closing connection")
+			return nil
 		}
 
 		logger.Green("packet %+v", packet)
@@ -158,10 +197,14 @@ func (s *Server) wsRead() (err error) {
 }
 
 func (s *Server) wsWrite(packet *domain.Packet) (err error) {
-	if (s.ws == nil) || (s.ws.RemoteAddr() == nil) {
+	s.wsMu.Lock()
+	conn := s.ws
+	s.wsMu.Unlock()
+
+	if conn == nil || conn.RemoteAddr() == nil {
 		return
 	}
-	err = s.ws.WriteJSON(packet)
+	err = conn.WriteJSON(packet)
 	return
 }
 


### PR DESCRIPTION
## Summary

Closes the three smallest-effort gaps from the WebSocket auth audit so an authenticated WS connection can no longer outlive its session.

- **Per-message session re-validation in `wsRead`.** After upgrade, the read loop captures the session id and re-checks it on every inbound packet via `sessionStillValid`. An expired, logged-out, or revoked session can no longer keep driving destructive operations through an already-upgraded connection. When auth is disabled the check is skipped (sessions don't exist).
- **Active websocket is closed when its backing session is cleared.** New helpers `closeWebsocketIfSession(sessionID)` and `closeAnyWebsocket()` are wired into `clearSession` (logout), `clearAllSessions` (setup / explicit reset), and `pruneSessions` (background expiry). The read loop's `ReadJSON` returns an error on close, the goroutine exits via the existing error path, and `defer conn.Close()` runs.
- **`upgrader.CheckOrigin` set explicitly.** Empty `Origin` and any cross-host upgrade attempt are now rejected regardless of the auth state. Hosts are compared (not schemes) so a TLS-terminating reverse proxy that strips the scheme still works. The per-request `validateWebsocketRequest` check in `auth.go` remains the session+CSRF gate when auth is enabled; this is defense-in-depth.

Bonus side-effect: `wsRead` now reads from a local `conn` parameter instead of the package-level `s.ws` field, so when a second client upgrades, the older goroutine stays bound to its own conn rather than racing to `ReadJSON` on the new one (gorilla forbids concurrent reads on the same conn). The "only the latest client gets broadcasts" UX limitation is unchanged; the unsafe race is gone. A full per-session conn map is deferred to pair with the planned WS small-payload migration.

## What this PR does NOT change

- Origin parity behind a TLS-terminating reverse proxy still depends on `c.IsTLS()` for the auth-on path's `validateWebsocketRequest`. That fix needs a trusted-proxy config knob — separate PR.
- CSRF token is still in the WS URL query string. Moving it to the first WS frame cross-cuts the UI — separate PR.
- WS surface is still wide open when `AUTH_ENABLED=false` (now with a same-host origin check in front of it as the only gate). Documenting that explicitly is a separate doc PR.

## Tests

- New unit tests in `daemon/services/server/auth_test.go`:
  - `TestSessionStillValid` — 4 cases (valid, expired, missing, empty session id).
  - `TestUpgraderCheckOrigin` — 7 cases including missing Origin, host mismatch, scheme difference (proxy case), and malformed Origin.
- All server + core tests pass on hal (cross-compiled `*.test` binary).

## Manual validation on hal (cross-tab smoke test)

Built canonical-style (`npm run build` + `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-X main.Version=2026.05.02-311cd8a-wsauth'`), installed at `/usr/local/emhttp/plugins/unbalanced/unbalanced`. A small Go client driven from the workstation set up auth, logged in once, opened WS A and WS B against the live daemon, then logged out. Daemon log:

```
unable to read websocket message: read tcp ...: use of closed network connection
websocket session no longer valid; closing connection
```

Both signals fire on the same logout: the first is the server-side `Close()` on the most-recent connection (WS B, in `s.ws`), the second is the per-message check on WS A's next packet. Subsequent writes on WS A surface as `broken pipe` once RST propagates.