### PR TITLE
Add dedicated login route

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useLocation, useNavigate, Outlet } from 'react-router-dom';
+import { useLocation, useNavigate, Outlet, Navigate } from 'react-router-dom';
 import { ThemeProvider } from '@/components/theme-provider';
 import ErrorBoundary from '@/components/error-boundary';
 import { AuthGate } from '@/components/auth-gate';
@@ -17,18 +17,34 @@ import {
   useAuthFailed,
   useAuthLoaded,
 } from './state/auth';
-import {
-  useUnraidActions,
-  useUnraidLoaded,
-} from './state/unraid';
+import { useUnraidActions, useUnraidLoaded } from './state/unraid';
+
+const DEFAULT_AUTHENTICATED_ROUTE = '/scatter/select';
+
+interface LoginLocationState {
+  from?: {
+    pathname?: string;
+    search?: string;
+    hash?: string;
+  };
+}
+
+function getReturnPath(state: unknown) {
+  const locationState = state as LoginLocationState | null;
+  const from = locationState?.from;
+
+  if (!from?.pathname || from.pathname === '/login') {
+    return DEFAULT_AUTHENTICATED_ROUTE;
+  }
+
+  return `${from.pathname}${from.search ?? ''}${from.hash ?? ''}`;
+}
 
 export function App() {
   const { getConfig } = useConfigActions();
   const { load } = useAuthActions();
   const { setNavigate, getUnraid, syncRoute, connectSocket, disconnectSocket } =
     useUnraidActions();
-  const isLoaded = useUnraidLoaded();
-  const version = useConfigVersion();
   const authLoaded = useAuthLoaded();
   const authEnabled = useAuthEnabled();
   const authFailed = useAuthFailed();
@@ -46,7 +62,6 @@ export function App() {
   }, [setNavigate, navigate]);
 
   React.useEffect(() => {
-    // console.log('sync location >>>>>>>>>>>>> ', location);
     syncRoute(location.pathname);
   }, [location, syncRoute]);
 
@@ -55,7 +70,8 @@ export function App() {
   }, [csrfToken]);
 
   React.useEffect(() => {
-    const shouldBlockForAuth = authFailed || (authLoaded && authEnabled && !authenticated);
+    const shouldBlockForAuth =
+      authFailed || (authLoaded && authEnabled && !authenticated);
 
     if (!authLoaded) {
       return;
@@ -80,19 +96,56 @@ export function App() {
     getUnraid,
   ]);
 
+  return (
+    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+      <ErrorBoundary>
+        <Outlet />
+      </ErrorBoundary>
+    </ThemeProvider>
+  );
+}
+
+export function LoginPage() {
+  const authLoaded = useAuthLoaded();
+  const authFailed = useAuthFailed();
+  const authEnabled = useAuthEnabled();
+  const authenticated = useAuthenticated();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const returnPath = getReturnPath(location.state);
+
   if (!authLoaded) {
     return null;
   }
 
-  const shouldShowAuthGate =
-    authFailed || (authLoaded && authEnabled && !authenticated);
+  if (!authFailed && (!authEnabled || authenticated)) {
+    return <Navigate to={returnPath} replace />;
+  }
 
-  if (shouldShowAuthGate) {
-    return (
-      <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-        <AuthGate />
-      </ThemeProvider>
-    );
+  return (
+    <AuthGate
+      onAuthenticated={() => {
+        navigate(returnPath, { replace: true });
+      }}
+    />
+  );
+}
+
+export function ProtectedLayout() {
+  const isLoaded = useUnraidLoaded();
+  const version = useConfigVersion();
+  const authLoaded = useAuthLoaded();
+  const authEnabled = useAuthEnabled();
+  const authFailed = useAuthFailed();
+  const authenticated = useAuthenticated();
+  const location = useLocation();
+
+  if (!authLoaded) {
+    return null;
+  }
+
+  if (authFailed || (authEnabled && !authenticated)) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
   }
 
   if (!(isLoaded && version !== '')) {
@@ -100,20 +153,16 @@ export function App() {
   }
 
   return (
-    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-      <ErrorBoundary>
-        <div className="container mx-auto h-screen flex flex-col">
-          <header>
-            <Header />
-          </header>
-          <main className="flex-1">
-            <Outlet />
-          </main>
-          <footer>
-            <Footer />
-          </footer>
-        </div>
-      </ErrorBoundary>
-    </ThemeProvider>
+    <div className="container mx-auto h-screen flex flex-col">
+      <header>
+        <Header />
+      </header>
+      <main className="flex-1">
+        <Outlet />
+      </main>
+      <footer>
+        <Footer />
+      </footer>
+    </div>
   );
 }

--- a/ui/src/components/auth-gate.tsx
+++ b/ui/src/components/auth-gate.tsx
@@ -12,7 +12,11 @@ import {
   useAuthUsername,
 } from '~/state/auth';
 
-export function AuthGate() {
+interface AuthGateProps {
+  onAuthenticated?: () => void;
+}
+
+export function AuthGate({ onAuthenticated }: AuthGateProps) {
   const enabled = useAuthEnabled();
   const configured = useAuthConfigured();
   const authError = useAuthError();
@@ -45,15 +49,17 @@ export function AuthGate() {
 
     setSubmitting(true);
 
-    if (isSetup) {
-      await setup(username, password);
-    } else {
-      await login(username, password);
-    }
+    const authenticated = isSetup
+      ? await setup(username, password)
+      : await login(username, password);
 
     setSubmitting(false);
     setPassword('');
     setConfirmPassword('');
+
+    if (authenticated) {
+      onAuthenticated?.();
+    }
   };
 
   return (
@@ -135,17 +141,13 @@ export function AuthGate() {
                 className="h-11 border-transparent bg-[#2b3850] shadow-[inset_0_1px_0_rgba(255,255,255,0.03),0_0_0_1px_rgba(18,24,38,0.35)] text-lg text-slate-100 placeholder:text-slate-500 focus-visible:border-transparent focus-visible:ring-1 focus-visible:ring-blue-400"
               />
               {confirmPassword !== '' && confirmPassword !== password && (
-                <p className="text-sm text-red-400">
-                  Passwords do not match.
-                </p>
+                <p className="text-sm text-red-400">Passwords do not match.</p>
               )}
             </div>
           )}
 
           {authError !== '' && (
-            <p className="text-sm text-red-400">
-              {authError}
-            </p>
+            <p className="text-sm text-red-400">{authError}</p>
           )}
 
           <Button
@@ -155,7 +157,8 @@ export function AuthGate() {
               submitting ||
               username.trim() === '' ||
               password === '' ||
-              (isSetup && (confirmPassword === '' || confirmPassword !== password))
+              (isSetup &&
+                (confirmPassword === '' || confirmPassword !== password))
             }
           >
             {isSetup ? 'Create Password' : 'Sign In'}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-router-dom';
 import { Toaster } from '@/components/ui/toaster';
 
-import { App } from './App.tsx';
+import { App, LoginPage, ProtectedLayout } from './App.tsx';
 import './index.css';
 import { Scatter } from '~/flows/scatter/scatter';
 import { Select as ScatterSelect } from '~/flows/scatter/select/select';
@@ -33,96 +33,115 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       {
-        path: '/scatter',
-        element: <Scatter />,
+        index: true,
+        element: <Navigate to="/scatter/select" replace />,
+      },
+      {
+        path: '/login',
+        element: <LoginPage />,
+      },
+      {
+        element: <ProtectedLayout />,
         children: [
-          { index: true, element: <Navigate to="/scatter/select" replace /> },
           {
-            path: 'select',
-            element: <ScatterSelect />,
-          },
-          {
-            path: 'plan',
-            element: <Feedback />,
-          },
-          {
-            path: 'transfer',
-            element: <Outlet />,
+            path: '/scatter',
+            element: <Scatter />,
             children: [
               {
-                path: 'validation',
-                element: <ScatterValidation />,
+                index: true,
+                element: <Navigate to="/scatter/select" replace />,
               },
               {
-                path: 'operation',
-                element: <Transfer />,
+                path: 'select',
+                element: <ScatterSelect />,
+              },
+              {
+                path: 'plan',
+                element: <Feedback />,
+              },
+              {
+                path: 'transfer',
+                element: <Outlet />,
+                children: [
+                  {
+                    path: 'validation',
+                    element: <ScatterValidation />,
+                  },
+                  {
+                    path: 'operation',
+                    element: <Transfer />,
+                  },
+                ],
               },
             ],
           },
-        ],
-      },
-      {
-        path: '/gather',
-        element: <Gather />,
-        children: [
-          { index: true, element: <Navigate to="/gather/select" replace /> },
           {
-            path: 'select',
-            element: <GatherSelect />,
-          },
-          {
-            path: 'plan',
-            element: <Feedback />,
-          },
-          {
-            path: 'transfer',
-            element: <Outlet />,
+            path: '/gather',
+            element: <Gather />,
             children: [
               {
-                path: 'targets',
-                element: <Targets />,
+                index: true,
+                element: <Navigate to="/gather/select" replace />,
               },
               {
-                path: 'operation',
-                element: <Transfer />,
+                path: 'select',
+                element: <GatherSelect />,
+              },
+              {
+                path: 'plan',
+                element: <Feedback />,
+              },
+              {
+                path: 'transfer',
+                element: <Outlet />,
+                children: [
+                  {
+                    path: 'targets',
+                    element: <Targets />,
+                  },
+                  {
+                    path: 'operation',
+                    element: <Transfer />,
+                  },
+                ],
               },
             ],
           },
+          {
+            path: '/history',
+            element: <History />,
+          },
+          {
+            path: '/settings',
+            element: <Settings />,
+            children: [
+              {
+                index: true,
+                element: <Navigate to="/settings/notifications" replace />,
+              },
+              {
+                path: 'notifications',
+                element: <Notifications />,
+              },
+              {
+                path: 'reserved',
+                element: <Reserved />,
+              },
+              {
+                path: 'flags',
+                element: <Flags />,
+              },
+              {
+                path: 'verbosity',
+                element: <Verbosity />,
+              },
+            ],
+          },
+          {
+            path: '/logs',
+            element: <Logs />,
+          },
         ],
-      },
-      {
-        path: '/history',
-        element: <History />,
-      },
-      {
-        path: '/settings',
-        element: <Settings />,
-        children: [
-          {
-            index: true,
-            element: <Navigate to="/settings/notifications" replace />,
-          },
-          {
-            path: 'notifications',
-            element: <Notifications />,
-          },
-          {
-            path: 'reserved',
-            element: <Reserved />,
-          },
-          {
-            path: 'flags',
-            element: <Flags />,
-          },
-          {
-            path: 'verbosity',
-            element: <Verbosity />,
-          },
-        ],
-      },
-      {
-        path: '/logs',
-        element: <Logs />,
       },
     ],
   },

--- a/ui/src/shared/header/header.tsx
+++ b/ui/src/shared/header/header.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useNavigate } from 'react-router-dom';
 import logo from '~/assets/unbalance-logo.png';
 import { ModeToggle } from '@/components/mode-toggle';
 import { Loading } from '~/shared/icons/loading';
@@ -11,6 +12,12 @@ export const Header: React.FunctionComponent = () => {
   const busy = useUnraidIsBusy();
   const authEnabled = useAuthEnabled();
   const { logout } = useAuthActions();
+  const navigate = useNavigate();
+
+  const onLogout = async () => {
+    await logout();
+    navigate('/login', { replace: true });
+  };
 
   return (
     <nav className="grid grid-cols-12 gap-2 my-4">
@@ -88,7 +95,7 @@ export const Header: React.FunctionComponent = () => {
         <li className="flex flex-row items-center">
           {busy && <Loading />}
           {authEnabled && (
-            <button className="mr-4 text-sm" onClick={() => void logout()}>
+            <button className="mr-4 text-sm" onClick={() => void onLogout()}>
               Log Out
             </button>
           )}


### PR DESCRIPTION
## Summary
- add a dedicated /login route for auth/setup UI
- wrap app routes in a protected layout that redirects unauthenticated users to /login
- navigate to /login after logout and return users to their original route after login

## Tests
- npm run build

Note: npm run lint is currently blocked because ESLint 9 expects eslint.config.* and the repo still has the older config setup.