### PR TITLE
Contain rsync execution paths

### DIFF
--- a/daemon/services/core/operation.go
+++ b/daemon/services/core/operation.go
@@ -40,20 +40,25 @@ func (c *Core) runOperation(opName string) {
 	commandsExecuted := make([]string, 0)
 
 	for _, command := range operation.Commands {
-		args := append(
-			operation.RsyncArgs,
-			command.Entry,
-			command.Dst,
-		)
+		paths, err := c.validateCommandForExecution(command)
+		if err != nil {
+			cmd := fmt.Sprintf(`rsync %s %s %s`, operation.RsyncStrArgs, strconv.Quote(command.Entry), strconv.Quote(command.Dst))
+			c.commandInterrupted(opName, operation, command, cmd, fmt.Errorf("unsafe command path: %w", err), 0, commandsExecuted)
+			return
+		}
 
-		cmd := fmt.Sprintf(`rsync %s %s %s`, operation.RsyncStrArgs, strconv.Quote(command.Entry), strconv.Quote(command.Dst))
-		logger.Blue("command started: (src: %s) %s ", command.Src, cmd)
+		command.Src = paths.SrcRoot
+		command.Dst = paths.DstRoot
+		command.Entry = paths.Entry
+
+		cmd := fmt.Sprintf(`rsync %s %s %s`, operation.RsyncStrArgs, strconv.Quote(paths.Entry), strconv.Quote(paths.DstRoot))
+		logger.Blue("command started: (src: %s) %s ", paths.SrcRoot, cmd)
 
 		operation.Line = cmd
 		packet := &domain.Packet{Topic: common.EventTransferProgress, Payload: operation}
 		c.ctx.Hub.Pub(packet, "socket:broadcast")
 
-		cmdTransferred, err := c.runCommand(operation, command, args)
+		cmdTransferred, err := c.runCommand(operation, command)
 		if err != nil {
 			c.commandInterrupted(opName, operation, command, cmd, err, cmdTransferred, commandsExecuted)
 			return
@@ -67,12 +72,27 @@ func (c *Core) runOperation(opName string) {
 	c.operationCompleted(opName, operation, commandsExecuted)
 }
 
-func (c *Core) runCommand(operation *domain.Operation, command *domain.Command, args []string) (uint64, error) {
+func (c *Core) runCommand(operation *domain.Operation, command *domain.Command) (uint64, error) {
+	paths, err := c.validateCommandForExecution(command)
+	if err != nil {
+		return 0, fmt.Errorf("unsafe command path: %w", err)
+	}
+
+	command.Src = paths.SrcRoot
+	command.Dst = paths.DstRoot
+	command.Entry = paths.Entry
+
+	args := append(
+		operation.RsyncArgs,
+		paths.Entry,
+		paths.DstRoot,
+	)
+
 	// make sure the command will run
 	c.stopped = false
 
 	// start rsync command
-	cmd, err := lib.StartRsync(command.Src, args...)
+	cmd, err := lib.StartRsync(paths.SrcRoot, args...)
 	if err != nil {
 		return 0, err
 	}

--- a/daemon/services/core/safepath.go
+++ b/daemon/services/core/safepath.go
@@ -96,6 +96,10 @@ type safeTransferPaths struct {
 }
 
 func safeCommandPaths(command *domain.Command) (safeTransferPaths, error) {
+	return safeCommandPathsWithin(command, nil)
+}
+
+func safeCommandPathsWithin(command *domain.Command, allowedRoots []string) (safeTransferPaths, error) {
 	if command == nil {
 		return safeTransferPaths{}, fmt.Errorf("missing command")
 	}
@@ -120,6 +124,16 @@ func safeCommandPaths(command *domain.Command) (safeTransferPaths, error) {
 		return safeTransferPaths{}, fmt.Errorf("source and destination roots must differ")
 	}
 
+	if len(allowedRoots) > 0 {
+		if !rootIsAllowed(srcRoot, allowedRoots) {
+			return safeTransferPaths{}, fmt.Errorf("source root is not an allowed disk root: %s", srcRoot)
+		}
+
+		if !rootIsAllowed(dstRoot, allowedRoots) {
+			return safeTransferPaths{}, fmt.Errorf("destination root is not an allowed disk root: %s", dstRoot)
+		}
+	}
+
 	return safeTransferPaths{
 		SrcRoot: srcRoot,
 		DstRoot: dstRoot,
@@ -127,6 +141,110 @@ func safeCommandPaths(command *domain.Command) (safeTransferPaths, error) {
 		SrcPath: srcPath,
 		DstPath: dstPath,
 	}, nil
+}
+
+func rootIsAllowed(root string, allowedRoots []string) bool {
+	cleanedRoot, err := cleanRoot(root)
+	if err != nil {
+		return false
+	}
+
+	for _, allowed := range allowedRoots {
+		cleanedAllowed, err := cleanRoot(allowed)
+		if err != nil {
+			continue
+		}
+
+		if cleanedRoot == cleanedAllowed {
+			return true
+		}
+	}
+
+	return false
+}
+
+func validateExistingPathBoundary(root, target string) error {
+	if err := validateSymlinkBoundary(root, target); err != nil {
+		return err
+	}
+
+	if _, err := os.Lstat(target); err != nil {
+		return fmt.Errorf("unable to inspect path %s: %w", target, err)
+	}
+
+	return nil
+}
+
+func validateCreatablePathBoundary(root, target string) error {
+	root, err := cleanRoot(root)
+	if err != nil {
+		return err
+	}
+
+	target = filepath.Clean(target)
+	if !pathIsInside(root, target) {
+		return fmt.Errorf("path escapes root: %s", target)
+	}
+
+	current := target
+	for {
+		_, statErr := os.Lstat(current)
+		if statErr == nil {
+			return validateSymlinkBoundary(root, current)
+		}
+
+		if !os.IsNotExist(statErr) {
+			return fmt.Errorf("unable to inspect path %s: %w", current, statErr)
+		}
+
+		if current == root {
+			return fmt.Errorf("root does not exist: %s", root)
+		}
+
+		current = filepath.Dir(current)
+	}
+}
+
+func validateCommandForExecution(command *domain.Command, allowedRoots []string) (safeTransferPaths, error) {
+	if len(allowedRoots) == 0 {
+		return safeTransferPaths{}, fmt.Errorf("no allowed disk roots available")
+	}
+
+	paths, err := safeCommandPathsWithin(command, allowedRoots)
+	if err != nil {
+		return safeTransferPaths{}, err
+	}
+
+	if err := validateExistingPathBoundary(paths.SrcRoot, paths.SrcPath); err != nil {
+		return paths, fmt.Errorf("invalid source path: %w", err)
+	}
+
+	if err := validateCreatablePathBoundary(paths.DstRoot, paths.DstPath); err != nil {
+		return paths, fmt.Errorf("invalid destination path: %w", err)
+	}
+
+	return paths, nil
+}
+
+func (c *Core) allowedTransferRoots() []string {
+	if c == nil || c.state == nil || c.state.Unraid == nil {
+		return nil
+	}
+
+	roots := make([]string, 0, len(c.state.Unraid.Disks))
+	for _, disk := range c.state.Unraid.Disks {
+		if disk == nil || disk.Path == "" {
+			continue
+		}
+
+		roots = append(roots, disk.Path)
+	}
+
+	return roots
+}
+
+func (c *Core) validateCommandForExecution(command *domain.Command) (safeTransferPaths, error) {
+	return validateCommandForExecution(command, c.allowedTransferRoots())
 }
 
 func removeTransferredSource(command *domain.Command, pruneParents bool) (string, []string, error) {

--- a/daemon/services/core/safepath_test.go
+++ b/daemon/services/core/safepath_test.go
@@ -44,6 +44,120 @@ func TestSafeJoinAllowsRelativeEntries(t *testing.T) {
 	}
 }
 
+func TestValidateCommandForExecutionAllowsContainedTransfer(t *testing.T) {
+	tmp := t.TempDir()
+	srcRoot := filepath.Join(tmp, "disk1")
+	dstRoot := filepath.Join(tmp, "disk2")
+	entry := filepath.Join("share", "movie", "file.mkv")
+
+	mustMkdirAll(t, filepath.Dir(filepath.Join(srcRoot, entry)))
+	mustWriteFile(t, filepath.Join(srcRoot, entry), "source")
+	mustMkdirAll(t, dstRoot)
+
+	paths, err := validateCommandForExecution(&domain.Command{
+		Src:   srcRoot + string(filepath.Separator),
+		Dst:   dstRoot,
+		Entry: entry,
+	}, []string{srcRoot, dstRoot})
+	if err != nil {
+		t.Fatalf("validateCommandForExecution returned error: %s", err)
+	}
+
+	if paths.SrcRoot != srcRoot || paths.DstRoot != dstRoot || paths.Entry != entry {
+		t.Fatalf("paths = %+v", paths)
+	}
+}
+
+func TestValidateCommandForExecutionRejectsRootsOutsideDisks(t *testing.T) {
+	tmp := t.TempDir()
+	srcRoot := filepath.Join(tmp, "disk1")
+	dstRoot := filepath.Join(tmp, "disk2")
+	outsideRoot := filepath.Join(tmp, "not-a-disk")
+	entry := filepath.Join("share", "movie")
+
+	mustMkdirAll(t, filepath.Join(outsideRoot, entry))
+	mustMkdirAll(t, dstRoot)
+
+	_, err := validateCommandForExecution(&domain.Command{
+		Src:   outsideRoot,
+		Dst:   dstRoot,
+		Entry: entry,
+	}, []string{srcRoot, dstRoot})
+	if err == nil {
+		t.Fatalf("expected non-disk source root to be rejected")
+	}
+}
+
+func TestValidateCommandForExecutionRejectsSourceSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior differs on windows")
+	}
+
+	tmp := t.TempDir()
+	srcRoot := filepath.Join(tmp, "disk1")
+	dstRoot := filepath.Join(tmp, "disk2")
+	outside := filepath.Join(tmp, "outside")
+	entry := filepath.Join("share", "escape")
+
+	mustMkdirAll(t, filepath.Join(srcRoot, "share"))
+	mustMkdirAll(t, dstRoot)
+	mustMkdirAll(t, outside)
+
+	if err := os.Symlink(outside, filepath.Join(srcRoot, entry)); err != nil {
+		t.Fatalf("unable to create symlink: %s", err)
+	}
+
+	_, err := validateCommandForExecution(&domain.Command{
+		Src:   srcRoot,
+		Dst:   dstRoot,
+		Entry: entry,
+	}, []string{srcRoot, dstRoot})
+	if err == nil {
+		t.Fatalf("expected source symlink escape to be rejected")
+	}
+}
+
+func TestValidateCommandForExecutionRejectsDestinationSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior differs on windows")
+	}
+
+	tmp := t.TempDir()
+	srcRoot := filepath.Join(tmp, "disk1")
+	dstRoot := filepath.Join(tmp, "disk2")
+	outside := filepath.Join(tmp, "outside")
+	entry := filepath.Join("share", "escape", "file.mkv")
+
+	mustMkdirAll(t, filepath.Dir(filepath.Join(srcRoot, entry)))
+	mustWriteFile(t, filepath.Join(srcRoot, entry), "source")
+	mustMkdirAll(t, filepath.Join(dstRoot, "share"))
+	mustMkdirAll(t, outside)
+
+	if err := os.Symlink(outside, filepath.Join(dstRoot, "share", "escape")); err != nil {
+		t.Fatalf("unable to create symlink: %s", err)
+	}
+
+	_, err := validateCommandForExecution(&domain.Command{
+		Src:   srcRoot,
+		Dst:   dstRoot,
+		Entry: entry,
+	}, []string{srcRoot, dstRoot})
+	if err == nil {
+		t.Fatalf("expected destination symlink escape to be rejected")
+	}
+}
+
+func TestValidateCommandForExecutionRequiresAllowedRoots(t *testing.T) {
+	_, err := validateCommandForExecution(&domain.Command{
+		Src:   filepath.Join(string(filepath.Separator), "mnt", "disk1"),
+		Dst:   filepath.Join(string(filepath.Separator), "mnt", "disk2"),
+		Entry: filepath.Join("share", "movie"),
+	}, nil)
+	if err == nil {
+		t.Fatalf("expected missing allowed roots to be rejected")
+	}
+}
+
 func TestRemoveTransferredSourceRemovesOnlyValidatedSource(t *testing.T) {
 	tmp := t.TempDir()
 	srcRoot := filepath.Join(tmp, "disk1")


### PR DESCRIPTION
## Summary
- add a final execution-time path containment gate before every rsync command starts
- derive allowed roots from the current Unraid disk list instead of trusting command payload roots
- normalize `Src`, `Dst`, and `Entry` before rsync args/logging, and reject `..`, absolute entries, non-disk roots, and symlink escapes
- add focused safepath tests for allowed transfers, non-disk roots, source symlink escapes, destination symlink parent escapes, and missing allowed roots

## Nuance / why this was still needed
PR #144 added `safepath.go` around source deletion, so move cleanup no longer shells out or deletes arbitrary paths. But rsync execution still had a residual gap: `runOperation` built args from `command.Entry` and `command.Dst`, then `runCommand` started rsync with `command.Src` as the working directory. Those command fields can come from stored/client-visible operation data, so deletion was guarded but the copy phase still needed its own containment check.

This PR puts the guard immediately before rsync invocation and repeats it inside `runCommand` as the final backstop.

## Validation
- `GOOS=linux GOARCH=amd64 go test -c ./daemon/services/core -o /tmp/unbalance-core-safepath.test`
- copied test binary to `hal:/tmp`, ran only `Test(SafeJoin|ValidateCommandForExecution|RemoveTransferredSource)`, all passed, removed temp binary
- `make release`

Note: native macOS `go test ./daemon/services/core` is still blocked by the existing Darwin compile mismatch in `array.go` (`int64(blockSize) != stat.Bsize`), so Linux-targeted validation was used.
