### PR TITLE
Harden auth file and packet logging hygiene

### DIFF
--- a/daemon/lib/utils.go
+++ b/daemon/lib/utils.go
@@ -173,6 +173,7 @@ func LoadEnv(location string, config *domain.Config) error {
 	if err != nil {
 		return err
 	}
+	_ = os.Chmod(location, 0o600)
 
 	// fill data
 	config.DryRun, _ = file.Section("").Key("DRY_RUN").Bool()
@@ -208,7 +209,18 @@ func SaveEnv(location string, config domain.Config) error {
 	file.Section("").Key("REFRESH_RATE").SetValue(strconv.Itoa(config.RefreshRate))
 	file.Section("").Key("AUTH_PASSWORD_HASH").SetValue(config.AuthPassword)
 
-	file.SaveTo(location)
+	tmpName := location + ".tmp"
+	if err := file.SaveTo(tmpName); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, location); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
 
-	return nil
+	return os.Chmod(location, 0o600)
 }

--- a/daemon/lib/utils_test.go
+++ b/daemon/lib/utils_test.go
@@ -1,0 +1,40 @@
+package lib
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"unbalance/daemon/domain"
+)
+
+func TestSaveEnvWritesRestrictivePermissions(t *testing.T) {
+	location := filepath.Join(t.TempDir(), "unbalanced.env")
+	if err := os.WriteFile(location, []byte("DRY_RUN=false\n"), 0o644); err != nil {
+		t.Fatalf("seed env: %s", err)
+	}
+
+	err := SaveEnv(location, domain.Config{
+		DryRun:         true,
+		NotifyPlan:     1,
+		NotifyTransfer: 2,
+		ReservedAmount: 42,
+		ReservedUnit:   "GB",
+		RsyncArgs:      []string{"-X"},
+		Verbosity:      1,
+		RefreshRate:    1000,
+		AuthPassword:   "$argon2id$v=19$m=1,t=1,p=1$c2FsdA$hash",
+	})
+	if err != nil {
+		t.Fatalf("SaveEnv returned error: %s", err)
+	}
+
+	info, err := os.Stat(location)
+	if err != nil {
+		t.Fatalf("stat env: %s", err)
+	}
+
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("env permissions = %o, want 600", got)
+	}
+}

--- a/daemon/services/core/core.go
+++ b/daemon/services/core/core.go
@@ -142,7 +142,7 @@ func (c *Core) mailboxHandler() {
 			var setup domain.ScatterSetup
 			err := lib.Bind(packet.Payload, &setup)
 			if err != nil {
-				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
+				logger.Red("unable to unmarshal %s packet: %s", packet.Topic, err)
 				continue
 			}
 			go c.scatterPlanPrepare(setup)
@@ -150,7 +150,7 @@ func (c *Core) mailboxHandler() {
 			var ref planRef
 			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
-				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
+				logger.Red("unable to unmarshal %s packet: %s", packet.Topic, err)
 				continue
 			}
 			go c.scatterMove(ref.PlanID)
@@ -158,7 +158,7 @@ func (c *Core) mailboxHandler() {
 			var ref planRef
 			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
-				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
+				logger.Red("unable to unmarshal %s packet: %s", packet.Topic, err)
 				continue
 			}
 			go c.scatterCopy(ref.PlanID)
@@ -167,7 +167,7 @@ func (c *Core) mailboxHandler() {
 			var setup domain.GatherSetup
 			err := lib.Bind(packet.Payload, &setup)
 			if err != nil {
-				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
+				logger.Red("unable to unmarshal %s packet: %s", packet.Topic, err)
 				continue
 			}
 			go c.gatherPlanPrepare(setup)
@@ -176,7 +176,7 @@ func (c *Core) mailboxHandler() {
 			var ref planRef
 			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
-				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
+				logger.Red("unable to unmarshal %s packet: %s", packet.Topic, err)
 				continue
 			}
 			go c.gatherMove(ref.PlanID, ref.Target)
@@ -185,7 +185,7 @@ func (c *Core) mailboxHandler() {
 			var ref operationRef
 			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
-				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
+				logger.Red("unable to unmarshal %s packet: %s", packet.Topic, err)
 				continue
 			}
 			go c.scatterValidate(ref.OperationID)
@@ -194,7 +194,7 @@ func (c *Core) mailboxHandler() {
 			var ref commandRef
 			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
-				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
+				logger.Red("unable to unmarshal %s packet: %s", packet.Topic, err)
 				continue
 			}
 			go c.removeSourceByID(ref.OperationID, ref.CommandID)
@@ -203,7 +203,7 @@ func (c *Core) mailboxHandler() {
 			var ref operationRef
 			err := lib.Bind(packet.Payload, &ref)
 			if err != nil {
-				logger.Red("unable to unmarshal packet: %+v (%s)", packet.Payload, err)
+				logger.Red("unable to unmarshal %s packet: %s", packet.Topic, err)
 				continue
 			}
 

--- a/daemon/services/server/auth.go
+++ b/daemon/services/server/auth.go
@@ -582,6 +582,7 @@ func (s *Server) loadSessions() error {
 		return err
 	}
 	defer file.Close()
+	_ = os.Chmod(location, 0o600)
 
 	var store sessionStore
 	if err := json.NewDecoder(file).Decode(&store); err != nil {
@@ -612,7 +613,7 @@ func (s *Server) saveSessionsLocked() error {
 	location := s.sessionFile()
 	tmpName := location + ".tmp"
 
-	file, err := os.Create(tmpName)
+	file, err := os.OpenFile(tmpName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -632,5 +633,9 @@ func (s *Server) saveSessionsLocked() error {
 		return err
 	}
 
-	return os.Rename(tmpName, location)
+	if err := os.Rename(tmpName, location); err != nil {
+		return err
+	}
+
+	return os.Chmod(location, 0o600)
 }

--- a/daemon/services/server/server.go
+++ b/daemon/services/server/server.go
@@ -190,7 +190,7 @@ func (s *Server) wsRead(conn *websocket.Conn, sessionID string) (err error) {
 			return nil
 		}
 
-		logger.Green("packet %+v", packet)
+		logger.Green("packet topic:%s", packet.Topic)
 
 		s.ctx.Hub.Pub(packet, packet.Topic)
 	}


### PR DESCRIPTION
## Summary
- write `unbalanced.env` through a restrictive temp file and chmod it to `0600` after load/save because it contains `AUTH_PASSWORD_HASH`
- write persisted auth sessions through a `0600` temp file and chmod existing session files on load
- stop logging full websocket packet payloads and bind-failure payloads; log packet topic + error instead
- add a unit test that verifies `SaveEnv` writes restrictive permissions

## Why
This is the small secrets/logging hygiene pass after the auth/path-containment hardening PRs. There were no obvious password/CSRF values being directly logged in normal auth handlers, but two low-risk improvements were available:

1. The env/session files contain password hashes, session IDs, and CSRF tokens, so they should not be world-readable if the platform honors permissions.
2. Full websocket packet payload logging is useful while debugging, but it creates unnecessary exposure if future payloads grow sensitive fields or include full operation objects.

## Validation
- `go test ./daemon/lib`
- `GOOS=linux GOARCH=amd64 go test -c ./daemon/services/server -o /tmp/unbalance-server.test`
- `GOOS=linux GOARCH=amd64 go test -c ./daemon/services/core -o /tmp/unbalance-core.test`
- `make release`

Note: native macOS server/core tests are still blocked by the existing Darwin compile mismatch in `array.go` (`int64(blockSize) != stat.Bsize`), so Linux-targeted compile validation was used for packages that pull in core.
