### PR TITLE
Introduce transfer executor boundary

### DIFF
--- a/daemon/services/core/core.go
+++ b/daemon/services/core/core.go
@@ -66,6 +66,8 @@ type Core struct {
 	pendingPlans   map[string]*planTicket
 	pendingPlansMu sync.Mutex
 
+	executor transferExecutor
+
 	stopped bool
 }
 
@@ -77,6 +79,7 @@ func Create(ctx *domain.Context) *Core {
 			Status: common.OpNeutral,
 		},
 		pendingPlans: make(map[string]*planTicket),
+		executor:     newInProcessExecutor(),
 		mailbox: ctx.Hub.Sub(
 			common.CommandScatterPlanStart,
 			common.CommandScatterMove,
@@ -89,6 +92,14 @@ func Create(ctx *domain.Context) *Core {
 			common.CommandStop,
 		),
 	}
+}
+
+func (c *Core) transferExecutor() transferExecutor {
+	if c.executor == nil {
+		c.executor = newInProcessExecutor()
+	}
+
+	return c.executor
 }
 
 func (c *Core) Start() error {

--- a/daemon/services/core/executor.go
+++ b/daemon/services/core/executor.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"os/exec"
+
+	"unbalance/daemon/domain"
+	"unbalance/daemon/lib"
+)
+
+type rsyncProcess interface {
+	PID() int
+	Kill() error
+	Wait() (int, error)
+}
+
+type transferExecutor interface {
+	PrepareCommand(command *domain.Command, allowedRoots []string) (safeTransferPaths, error)
+	StartRsync(workDir string, args ...string) (rsyncProcess, error)
+	RemoveTransferredSource(command *domain.Command, pruneParents bool) (string, []string, error)
+}
+
+type inProcessExecutor struct{}
+
+func newInProcessExecutor() transferExecutor {
+	return inProcessExecutor{}
+}
+
+func (inProcessExecutor) PrepareCommand(command *domain.Command, allowedRoots []string) (safeTransferPaths, error) {
+	return validateCommandForExecution(command, allowedRoots)
+}
+
+func (inProcessExecutor) StartRsync(workDir string, args ...string) (rsyncProcess, error) {
+	cmd, err := lib.StartRsync(workDir, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	return execRsyncProcess{cmd: cmd}, nil
+}
+
+func (inProcessExecutor) RemoveTransferredSource(command *domain.Command, pruneParents bool) (string, []string, error) {
+	return removeTransferredSource(command, pruneParents)
+}
+
+type execRsyncProcess struct {
+	cmd *exec.Cmd
+}
+
+func (p execRsyncProcess) PID() int {
+	return p.cmd.Process.Pid
+}
+
+func (p execRsyncProcess) Kill() error {
+	return lib.KillRsync(p.cmd)
+}
+
+func (p execRsyncProcess) Wait() (int, error) {
+	return lib.EndRsync(p.cmd)
+}

--- a/daemon/services/core/operation.go
+++ b/daemon/services/core/operation.go
@@ -40,7 +40,7 @@ func (c *Core) runOperation(opName string) {
 	commandsExecuted := make([]string, 0)
 
 	for _, command := range operation.Commands {
-		paths, err := c.validateCommandForExecution(command)
+		paths, err := c.prepareCommandForExecution(command)
 		if err != nil {
 			cmd := fmt.Sprintf(`rsync %s %s %s`, operation.RsyncStrArgs, strconv.Quote(command.Entry), strconv.Quote(command.Dst))
 			c.commandInterrupted(opName, operation, command, cmd, fmt.Errorf("unsafe command path: %w", err), 0, commandsExecuted)
@@ -73,7 +73,7 @@ func (c *Core) runOperation(opName string) {
 }
 
 func (c *Core) runCommand(operation *domain.Operation, command *domain.Command) (uint64, error) {
-	paths, err := c.validateCommandForExecution(command)
+	paths, err := c.prepareCommandForExecution(command)
 	if err != nil {
 		return 0, fmt.Errorf("unsafe command path: %w", err)
 	}
@@ -92,7 +92,7 @@ func (c *Core) runCommand(operation *domain.Operation, command *domain.Command) 
 	c.stopped = false
 
 	// start rsync command
-	cmd, err := lib.StartRsync(paths.SrcRoot, args...)
+	cmd, err := c.transferExecutor().StartRsync(paths.SrcRoot, args...)
 	if err != nil {
 		return 0, err
 	}
@@ -101,12 +101,12 @@ func (c *Core) runCommand(operation *domain.Operation, command *domain.Command) 
 	time.Sleep(500 * time.Millisecond)
 
 	// monitor rsync progress
-	retcode, transferred := c.monitorRsync(operation, command, cmd.Process.Pid)
+	retcode, transferred := c.monitorRsync(operation, command, cmd.PID())
 
 	// 99 is a magic number meaning the user clicked on the stop operation button
 	if retcode == 99 {
 		logger.Blue("command:received:StopCommand")
-		err = lib.KillRsync(cmd)
+		err = cmd.Kill()
 		if err != nil {
 			logger.Yellow("command:kill:error(%s)", err)
 		}
@@ -118,7 +118,7 @@ func (c *Core) runCommand(operation *domain.Operation, command *domain.Command) 
 	command.Status = common.CmdCompleted
 
 	// end rsync process
-	exitCode, err := lib.EndRsync(cmd)
+	exitCode, err := cmd.Wait()
 	if err != nil {
 		logger.Yellow("command:end:error(%s)", err)
 		command.Status = common.CmdStopped
@@ -290,7 +290,7 @@ func (c *Core) handleItemDeletion(operation *domain.Operation, command *domain.C
 		packet := &domain.Packet{Topic: common.EventTransferProgress, Payload: operation}
 		c.ctx.Hub.Pub(packet, "socket:broadcast")
 
-		removed, pruned, err := removeTransferredSource(command, operation.OpKind == common.OpGatherMove)
+		removed, pruned, err := c.transferExecutor().RemoveTransferredSource(command, operation.OpKind == common.OpGatherMove)
 		if err != nil {
 			msg := fmt.Sprintf("Unable to remove source folder (%s): %s", filepath.Join(command.Src, command.Entry), err)
 			operation.Line = msg

--- a/daemon/services/core/safepath.go
+++ b/daemon/services/core/safepath.go
@@ -243,8 +243,8 @@ func (c *Core) allowedTransferRoots() []string {
 	return roots
 }
 
-func (c *Core) validateCommandForExecution(command *domain.Command) (safeTransferPaths, error) {
-	return validateCommandForExecution(command, c.allowedTransferRoots())
+func (c *Core) prepareCommandForExecution(command *domain.Command) (safeTransferPaths, error) {
+	return c.transferExecutor().PrepareCommand(command, c.allowedTransferRoots())
 }
 
 func removeTransferredSource(command *domain.Command, pruneParents bool) (string, []string, error) {


### PR DESCRIPTION
## Summary

- introduce an in-process transfer executor boundary around command execution
- route command path preparation, rsync start/wait/kill, and guarded source cleanup through the executor
- keep current single-process behavior and rsync cwd/relative-path semantics unchanged

This is the first foundation step toward the later lean core + restricted worker split. It intentionally does **not** introduce a socket, worker process, startup script changes, or privilege changes.

## Validation

- `go test ./daemon/lib`
- `GOOS=linux GOARCH=amd64 go test -c ./daemon/services/core -o /tmp/unbalance-core-executor.test`
- `GOOS=linux GOARCH=amd64 go test -c ./daemon/services/server -o /tmp/unbalance-server-executor.test`
- `make release`

## Manual hal validation

Test binary deployed to `/usr/local/emhttp/plugins/unbalanced/unbalanced` on `hal` with backup:

- backup: `/usr/local/emhttp/plugins/unbalanced/unbalanced.bak.20260503-095840`
- sha256: `7f8b826e6b750c63079beb0d1536dd829711d787bc6472f4b63da8337450f4b5`

Manual fixture validation passed:

- Scatter copy with two 1 GiB payload files: completed with `retcode(0):exitcode(0)` and expected destination files/checksums.
- Scatter move with the same fixture: completed with `retcode(0):exitcode(0)`, removed source folders, preserved destination payload.
- Gather move disk2 → disk1 with 512 MiB + 256 MiB payloads: completed with `retcode(0):exitcode(0)`, removed source folders, pruned the source fixture root, and verified final disk1 filesystem state.

No unsafe-path, blocked, interrupted, or operation error lines were observed for the executor-interface fixtures.

## Notes

Native macOS core tests are still blocked by the existing Darwin compile mismatch in `daemon/services/core/array.go`; Linux-targeted core/server compilation was used as the validation gate for those packages.
