### PR TITLE
Fix gather plan log label

### DIFF
--- a/daemon/services/core/gather.go
+++ b/daemon/services/core/gather.go
@@ -94,7 +94,7 @@ func (c *Core) gatherPlanStart(plan *domain.Plan) {
 		reserved := c.getReservedAmount(disk.Size)
 
 		ceil := lib.Max(common.ReservedSpace, reserved)
-		logger.Blue("scatterPlan:ItemsLeft(%d):ReservedSpace(%d)", len(items), ceil)
+		logger.Blue("gatherPlan:ItemsLeft(%d):ReservedSpace(%d)", len(items), ceil)
 
 		packer := algorithm.NewGreedy(disk, items, ceil, c.state.Unraid.BlockSize)
 		bin := packer.FitAll()


### PR DESCRIPTION
## Summary
- correct the gather planner allocation log label from scatterPlan to gatherPlan

## Verification
- GOOS=linux go test -c ./daemon/services/core